### PR TITLE
[FIXED JENKINS-21374] Allow disabling ROLE_ creation

### DIFF
--- a/src/main/resources/hudson/security/LDAPBindSecurityRealm.groovy
+++ b/src/main/resources/hudson/security/LDAPBindSecurityRealm.groovy
@@ -65,7 +65,7 @@ bindAuthenticator(BindAuthenticator2,initialDirContextFactory) {
     userSearch = ldapUserSearch;
 }
 
-authoritiesPopulator(AuthoritiesPopulatorImpl, initialDirContextFactory, instance.groupSearchBase) {
+authoritiesPopulator(AuthoritiesPopulatorImpl, initialDirContextFactory, instance.groupSearchBase, instance.disablePrefixedRoleCreation) {
     // see DefaultLdapAuthoritiesPopulator for other possible configurations
     searchSubtree = true;
     groupSearchFilter = "(| (member={0}) (uniqueMember={0}) (memberUid={1}))";

--- a/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
+++ b/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
@@ -68,6 +68,9 @@ THE SOFTWARE.
     <f:entry title="${%Disable Ldap Email Resolver}">
       <f:checkbox name="ldap.disableMailAddressResolver" checked="${instance.disableMailAddressResolver}"></f:checkbox>
     </f:entry>
+    <f:entry title="${%Disable Backward Compatibility for Roles}" help="/plugin/ldap/help-disablePrefixedRoleCreation.html">
+      <f:checkbox name="ldap.disablePrefixedRoleCreation" checked="${instance.disablePrefixedRoleCreation}"></f:checkbox>
+    </f:entry>
     <f:optionalBlock name="ldap.cache" title="${%Enable cache}" checked="${instance.cache != null}" help="/plugin/ldap/help-cache.html">
       <f:entry title="${%Cache size}">
         <f:radio name="ldap.cache.size" value="10" checked="${instance.cacheSize == 10}" title="10"/>

--- a/src/main/webapp/help-disablePrefixedRoleCreation.html
+++ b/src/main/webapp/help-disablePrefixedRoleCreation.html
@@ -1,0 +1,4 @@
+<div>
+    For backwards compatibility reasons, the LDAP plugin will create a role <code>ROLE_FOO</code> for every role/group <code>Foo</code> of a user by default.
+    If you're not using these <code>ROLE_*</code> roles in your security configuration and don't want this duplication of roles, you can check this option so they'll no longer be created.
+</div>

--- a/src/test/groovy/hudson/security/LDAPSecurityRealmTest.groovy
+++ b/src/test/groovy/hudson/security/LDAPSecurityRealmTest.groovy
@@ -42,7 +42,7 @@ public class LDAPSecurityRealmTest extends HudsonTestCase {
      * basic syntax errors and such.
      */
     void testGroovyBeanDef() {
-        hudson.securityRealm = new LDAPSecurityRealm("ldap.itd.umich.edu",null,null,null,null,null,null,false);
+        hudson.securityRealm = new LDAPSecurityRealm("ldap.itd.umich.edu",null,null,null,null,null,null,false, false);
         println hudson.securityRealm.securityComponents // force the component creation
     }
 


### PR DESCRIPTION
Adds another option to disable creation of `ROLE_` roles for those of us who've never used them, and never will.

Advantages:
- No role duplication (reduces roles/groups list by half when accessing a user's page)
- No user confusion

Another option would be to add another system property if that's preferred over another option.
