### PR TITLE
Make GROUP_SEARCH final as run-time mutability has been obsoleted by …

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1109,7 +1109,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
      * See http://msdn.microsoft.com/en-us/library/aa746475(VS.85).aspx for the syntax by example.
      * WANTED: The specification of the syntax.
      */
-    public static String GROUP_SEARCH = System.getProperty(LDAPSecurityRealm.class.getName()+".groupSearch",
+    public static final String GROUP_SEARCH = System.getProperty(LDAPSecurityRealm.class.getName()+".groupSearch",
             "(& (cn={0}) (| (objectclass=groupOfNames) (objectclass=groupOfUniqueNames) (objectclass=posixGroup)))");
 
     public static class CacheConfiguration extends AbstractDescribableImpl<CacheConfiguration> {


### PR DESCRIPTION
…other changes

This field was runtime mutable only because prior to the group search being exposed via the UI it was the only way to modify the search.

When the group search was exposed in the UI this field's behaviour was changed from being the actual value used to being the initial default value and as such there is no need for it to be run-time modifiable.

@reviewbybees