### PR TITLE
Bump parent pom version to 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.3</version>
+    <version>2.6</version>
   </parent>
 
   <artifactId>ldap</artifactId>


### PR DESCRIPTION
In order to make the build of the plugin stable using baseline 2.0-rc-1, the parent pom to use must be 2.4+ where version 2.6 of the Jenkins Test Harness is picked up.

@reviewbybees 