### PR TITLE
[FIXED JENKINS-43994] When the user can login but lookup fails report this as a potential issue for API tokens and SSH key base authentication of the user

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1540,6 +1540,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
                     .append(jenkins.security.plugins.ldap.Messages.LDAPSecurityRealm_LoginHeader())
                     .append("</div>");
             boolean potentialLockout = false;
+            boolean likelyLockout = false;
 
             // can we login?
             LdapUserDetails loginDetails = null;
@@ -1557,6 +1558,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
                     error(response, "authentication",
                             jenkins.security.plugins.ldap.Messages.LDAPSecurityRealm_AuthenticationFailed(user));
                     potentialLockout = true;
+                    likelyLockout = true;
                 }
             }
             Set<String> loginAuthorities = new HashSet<>();
@@ -1820,7 +1822,8 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
                         .append(jenkins.security.plugins.ldap.Messages.LDAPSecurityRealm_LockoutHeader())
                         .append("</div>");
                 error(response, "lockout",
-                        jenkins.security.plugins.ldap.Messages.LDAPSecurityRealm_PotentialLockout(user)
+                        likelyLockout ? jenkins.security.plugins.ldap.Messages.LDAPSecurityRealm_PotentialLockout(user)
+                                : jenkins.security.plugins.ldap.Messages.LDAPSecurityRealm_PotentialLockout2(user)
                 );
             }
             // and we are done, report the results

--- a/src/main/resources/jenkins/security/plugins/ldap/Messages.properties
+++ b/src/main/resources/jenkins/security/plugins/ldap/Messages.properties
@@ -51,3 +51,7 @@ LDAPSecurityRealm.LockoutHeader=Lockout
 LDAPSecurityRealm.PotentialLockout=The user "{0}" will be unable to login with the supplied password.<br/>\
   If this is your own account this would mean you would be locked out!<br/>\
   Are you sure you want to save this configuration?
+LDAPSecurityRealm.PotentialLockout2=The user "{0}" may be unable to login with API tokens or SSH keys.<br/>\
+  The user will have inconsistent permissions if able to login using API tokens or SSH keys!<br/>\
+  If this is your own account this could mean you may be locked out!<br/>\
+  Are you sure you want to save this configuration?


### PR DESCRIPTION
See [JENKINS-43994](https://issues.jenkins-ci.org/browse/JENKINS-43994)

@reviewbybees