### PR TITLE
[JENKINS-21784] Add support for querying group membership

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -44,7 +44,7 @@ import jenkins.model.Jenkins;
 import jenkins.security.plugins.ldap.FromGroupSearchLDAPGroupMembershipStrategy;
 import jenkins.security.plugins.ldap.LDAPConfiguration;
 import jenkins.security.plugins.ldap.LDAPGroupMembershipStrategy;
-import jenkins.security.plugins.ldap.LDAPSearchUtils;
+import jenkins.security.plugins.ldap.LDAPExtendedTemplate;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.acegisecurity.AcegiSecurityException;
@@ -57,7 +57,6 @@ import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.ldap.InitialDirContextFactory;
 import org.acegisecurity.ldap.LdapDataAccessException;
 import org.acegisecurity.ldap.LdapEntryMapper;
-import org.acegisecurity.ldap.LdapTemplate;
 import org.acegisecurity.ldap.LdapUserSearch;
 import org.acegisecurity.ldap.search.FilterBasedLdapUserSearch;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
@@ -880,8 +879,9 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
         for (LDAPConfiguration conf : configurations) {
             String searchBase = conf.getGroupSearchBase() != null ? conf.getGroupSearchBase() : "";
             String searchFilter = conf.getGroupSearchFilter() != null ? conf.getGroupSearchFilter() : GROUP_SEARCH;
-            LdapTemplate template = conf.getLdapTemplate();
-            GroupDetailsImpl groupDetails = (GroupDetailsImpl)LDAPSearchUtils.searchForFirstEntry(template, searchBase, searchFilter, new Object[]{groupname}, new String[]{}, new GroupDetailsMapper());
+            LDAPExtendedTemplate template = conf.getLdapTemplate();
+            GroupDetailsImpl groupDetails = (GroupDetailsImpl)template.searchForFirstEntry(searchBase, searchFilter,
+                    new Object[]{groupname}, new String[]{}, new GroupDetailsMapper());
             if (groupDetails != null) {
                 if (fetchMembers) {
                     Set<String> members = conf.getGroupMembershipStrategy().getGroupMembers(groupDetails.getDn(), conf);

--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -870,7 +870,6 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             cachedGroup = null;
         }
 
-        // TODO: obtain a DN instead so that we can obtain multiple attributes later
         final GroupDetailsImpl group = cachedGroup != null
                 ? cachedGroup
                 : searchForGroupName(groupname, fetchMembers);

--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -845,36 +845,36 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
     @Override
     public GroupDetails loadGroupByGroupname(String groupname, boolean fetchMembers) throws UsernameNotFoundException, DataAccessException {
         groupname = fixGroupname(groupname);
-        GroupDetails cachedGroups;
+        GroupDetails cachedGroup;
         if (cache != null) {
             final CacheEntry<GroupDetails> cached;
             synchronized (this) {
                 cached = groupDetailsCache != null ? groupDetailsCache.get(groupname) : null;
             }
             if (cached != null && cached.isValid()) {
-                cachedGroups = cached.getValue();
+                cachedGroup = cached.getValue();
             } else {
-                cachedGroups = null;
+                cachedGroup = null;
             }
         } else {
-            cachedGroups = null;
+            cachedGroup = null;
         }
 
         // TODO: obtain a DN instead so that we can obtain multiple attributes later
 
-        final GroupDetails groups = cachedGroups != null
-                ? cachedGroups
+        final GroupDetails group = cachedGroup != null
+                ? cachedGroup
                 : searchForGroupName(groupname, fetchMembers);
-        if (cache != null && cachedGroups == null) {
+        if (cache != null && cachedGroup == null) {
             synchronized (this) {
                 if (groupDetailsCache == null) {
                     groupDetailsCache = new CacheMap<>(cache.getSize());
                 }
-                groupDetailsCache.put(groupname, new CacheEntry<>(cache.getTtl(), groups));
+                groupDetailsCache.put(groupname, new CacheEntry<>(cache.getTtl(), group));
             }
         }
 
-        return groups;
+        return group;
     }
 
     private @Nonnull GroupDetails searchForGroupName(String groupname, boolean fetchMembers) {

--- a/src/main/java/jenkins/security/plugins/ldap/FromGroupSearchLDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/FromGroupSearchLDAPGroupMembershipStrategy.java
@@ -25,11 +25,24 @@ package jenkins.security.plugins.ldap;
 
 import hudson.Extension;
 import hudson.security.LDAPSecurityRealm;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.naming.InvalidNameException;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.ldap.LdapName;
 import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.ldap.LdapEntryMapper;
+import org.acegisecurity.ldap.LdapTemplate;
 import org.acegisecurity.providers.ldap.LdapAuthoritiesPopulator;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.springframework.dao.DataAccessException;
 
 /**
  * Traditional strategy.
@@ -37,6 +50,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class FromGroupSearchLDAPGroupMembershipStrategy extends LDAPGroupMembershipStrategy {
 
+    private static final Logger LOGGER = Logger.getLogger(FromGroupSearchLDAPGroupMembershipStrategy.class.getName());
     /**
      * The search filter to apply to groups. Only those groups matching this criteria will be considered as groups
      * that the user belongs to.
@@ -68,12 +82,56 @@ public class FromGroupSearchLDAPGroupMembershipStrategy extends LDAPGroupMembers
         return getAuthoritiesPopulator().getGrantedAuthorities(ldapUser);
     }
 
+    @Override
+    public Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException {
+        LdapTemplate template = conf.getLdapTemplate();
+        String[] memberAttributes = { "member", "uniqueMember", "memberUid" };
+        return (Set<String>) template.retrieveEntry(groupDn, new GroupMembersMapper(), memberAttributes);
+    }
+
     @Extension
     public static class DescriptorImpl extends LDAPGroupMembershipStrategyDescriptor {
 
         @Override
         public String getDisplayName() {
             return Messages.FromGroupSearchLDAPGroupMembershipStrategy_DisplayName();
+        }
+    }
+
+    /**
+     * Maps member attributes in groups to a set of member names.
+     */
+    private static class GroupMembersMapper implements LdapEntryMapper {
+        @Override
+        public Set<String> mapAttributes(String dn, Attributes attributes) throws NamingException {
+            NamingEnumeration<?> enumeration;
+            boolean expectingUidInsteadOfDn = false;
+            if (attributes.get("member") != null) {
+                enumeration = attributes.get("member").getAll();
+            } else if (attributes.get("uniqueMember") != null) {
+                enumeration = attributes.get("uniqueMember").getAll();
+            } else if (attributes.get("memberUid") != null) {
+                enumeration = attributes.get("memberUid").getAll();
+                expectingUidInsteadOfDn = true;
+            } else {
+                LOGGER.log(Level.FINEST, "No members for {0}", dn);
+                return Collections.emptySet();
+            }
+            Set<String> members = new TreeSet<>();
+            while (enumeration.hasMore()) {
+                String memberDn = String.valueOf(enumeration.next());
+                if (expectingUidInsteadOfDn) {
+                    members.add(memberDn);
+                } else {
+                    try {
+                        LdapName memberName = new LdapName(memberDn);
+                        members.add(String.valueOf(memberName.getRdn(memberName.size() - 1).getValue()));
+                    } catch (InvalidNameException e) {
+                        LOGGER.log(Level.FINEST, "Expecting DN but found {0}", memberDn);
+                    }
+                }
+            }
+            return members;
         }
     }
 }

--- a/src/main/java/jenkins/security/plugins/ldap/FromGroupSearchLDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/FromGroupSearchLDAPGroupMembershipStrategy.java
@@ -37,7 +37,6 @@ import javax.naming.directory.Attributes;
 import javax.naming.ldap.LdapName;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.ldap.LdapEntryMapper;
-import org.acegisecurity.ldap.LdapTemplate;
 import org.acegisecurity.providers.ldap.LdapAuthoritiesPopulator;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
 import org.apache.commons.lang.StringUtils;
@@ -84,7 +83,7 @@ public class FromGroupSearchLDAPGroupMembershipStrategy extends LDAPGroupMembers
 
     @Override
     public Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException {
-        LdapTemplate template = conf.getLdapTemplate();
+        LDAPExtendedTemplate template = conf.getLdapTemplate();
         String[] memberAttributes = { "member", "uniqueMember", "memberUid" };
         return (Set<String>) template.retrieveEntry(groupDn, new GroupMembersMapper(), memberAttributes);
     }

--- a/src/main/java/jenkins/security/plugins/ldap/FromUserRecordLDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/FromUserRecordLDAPGroupMembershipStrategy.java
@@ -123,11 +123,10 @@ public class FromUserRecordLDAPGroupMembershipStrategy extends LDAPGroupMembersh
     @Override
     public Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException {
         LDAPExtendedTemplate template = conf.getLdapTemplate();
-        String attributeName = getAttributeName();
-        String[] params = { attributeName, groupDn };
-        String[] attributeNames = { attributeName };
-        return new HashSet<>((List<String>)template.searchForAllEntries(conf.getUserSearchBase(), USER_SEARCH_FILTER,
-                params, attributeNames, new UserRecordMapper()));
+        String searchBase = conf.getUserSearchBase() != null ? conf.getUserSearchBase() : "";
+        String[] filterArgs = { getAttributeName(), groupDn };
+        return new HashSet<>((List<String>)template.searchForAllEntries(searchBase, USER_SEARCH_FILTER,
+                filterArgs, new String[]{}, new UserRecordMapper()));
     }
 
     /**

--- a/src/main/java/jenkins/security/plugins/ldap/FromUserRecordLDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/FromUserRecordLDAPGroupMembershipStrategy.java
@@ -28,9 +28,12 @@ import hudson.security.LDAPSecurityRealm;
 import java.util.Set;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
+import org.acegisecurity.ldap.LdapEntryMapper;
+import org.acegisecurity.ldap.LdapTemplate;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.springframework.dao.DataAccessException;
 
 import javax.naming.InvalidNameException;
 import javax.naming.NamingException;
@@ -39,6 +42,7 @@ import javax.naming.directory.Attributes;
 import javax.naming.ldap.LdapName;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -51,6 +55,7 @@ import java.util.logging.Logger;
 public class FromUserRecordLDAPGroupMembershipStrategy extends LDAPGroupMembershipStrategy {
 
     private static final Logger LOGGER = Logger.getLogger(FromUserRecordLDAPGroupMembershipStrategy.class.getName());
+    private static final String USER_SEARCH_FILTER = "({0}={1})";
     private final String attributeName;
 
     @DataBoundConstructor
@@ -114,6 +119,27 @@ public class FromUserRecordLDAPGroupMembershipStrategy extends LDAPGroupMembersh
         }
 
         return result.toArray(new GrantedAuthority[result.size()]);
+    }
+
+    @Override
+    public Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException {
+        LdapTemplate template = conf.getLdapTemplate();
+        String attributeName = getAttributeName();
+        String[] params = { attributeName, groupDn };
+        String[] attributeNames = { attributeName };
+        return new HashSet<>((List<String>)LDAPSearchUtils.searchForAllEntries(template, conf.getUserSearchBase(),
+                USER_SEARCH_FILTER, params, attributeNames, new UserRecordMapper()));
+    }
+
+    /**
+     * Maps users records to names.
+     */
+    private static class UserRecordMapper implements LdapEntryMapper {
+        @Override
+        public String mapAttributes(String dn, Attributes attributes) throws NamingException {
+            LdapName name = new LdapName(dn);
+            return String.valueOf(name.getRdn(name.size() - 1).getValue());
+        }
     }
 
     @Extension

--- a/src/main/java/jenkins/security/plugins/ldap/FromUserRecordLDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/FromUserRecordLDAPGroupMembershipStrategy.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
 import org.acegisecurity.ldap.LdapEntryMapper;
-import org.acegisecurity.ldap.LdapTemplate;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -123,12 +122,12 @@ public class FromUserRecordLDAPGroupMembershipStrategy extends LDAPGroupMembersh
 
     @Override
     public Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException {
-        LdapTemplate template = conf.getLdapTemplate();
+        LDAPExtendedTemplate template = conf.getLdapTemplate();
         String attributeName = getAttributeName();
         String[] params = { attributeName, groupDn };
         String[] attributeNames = { attributeName };
-        return new HashSet<>((List<String>)LDAPSearchUtils.searchForAllEntries(template, conf.getUserSearchBase(),
-                USER_SEARCH_FILTER, params, attributeNames, new UserRecordMapper()));
+        return new HashSet<>((List<String>)template.searchForAllEntries(conf.getUserSearchBase(), USER_SEARCH_FILTER,
+                params, attributeNames, new UserRecordMapper()));
     }
 
     /**

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
@@ -135,7 +135,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
     /**
      * Set in {@link #createApplicationContext(LDAPSecurityRealm, boolean)}
      */
-    private transient LdapTemplate ldapTemplate;
+    private transient LDAPExtendedTemplate ldapTemplate;
     private transient String id;
 
     @DataBoundConstructor
@@ -585,7 +585,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
         }
         WebApplicationContext appContext = builder.createApplicationContext();
 
-        ldapTemplate = new LdapTemplate(SecurityRealm.findBean(InitialDirContextFactory.class, appContext));
+        ldapTemplate = new LDAPExtendedTemplate(SecurityRealm.findBean(InitialDirContextFactory.class, appContext));
 
         if (groupMembershipStrategy != null) {
             groupMembershipStrategy.setAuthoritiesPopulator(SecurityRealm.findBean(LdapAuthoritiesPopulator.class, appContext));
@@ -595,7 +595,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
     }
 
     @Restricted(NoExternalUse.class)
-    public LdapTemplate getLdapTemplate() {
+    public LDAPExtendedTemplate getLdapTemplate() {
         return ldapTemplate;
     }
 

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPExtendedTemplate.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPExtendedTemplate.java
@@ -24,17 +24,20 @@
 
 package jenkins.security.plugins.ldap;
 
+import org.acegisecurity.AuthenticationException;
 import org.acegisecurity.ldap.InitialDirContextFactory;
 import org.acegisecurity.ldap.LdapCallback;
 import org.acegisecurity.ldap.LdapDataAccessException;
 import org.acegisecurity.ldap.LdapEntryMapper;
 import org.acegisecurity.ldap.LdapTemplate;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.dao.DataAccessException;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
@@ -53,20 +56,21 @@ public class LDAPExtendedTemplate extends LdapTemplate {
      * Performs a search using the specified filter and returns the first matching entry using the
      * given {@link LdapEntryMapper} to convert the entry into a result.
      *
-     * @param base the DN to search in.
-     * @param filter the search filter to use.
-     * @param params the parameters to substitute in the search filter.
+     * @param base the DN to search in. Must not be null.
+     * @param filter the search filter to use. Must not be null.
+     * @param filterArgs the arguments to substitute into the search filter. Passing null is equivalent to an empty array.
      * @param attributeNames the attributes whose values will be retrieved. Passing null returns all attributes.
-     * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values.
+     * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values. Must not be null.
      *
      * @return the first matching entry converted using the specified {@link LdapEntryMapper}, or null if no matching
      * entry was found.
      *
      * @see LdapTemplate#searchForSingleEntry
      */
-    public Object searchForFirstEntry(final String base, final String filter, final Object[] params,
-            final String[] attributeNames, final LdapEntryMapper mapper) throws DataAccessException {
-        try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(base, filter, params, attributeNames, mapper)) {
+    public @CheckForNull Object searchForFirstEntry(@Nonnull final String base, @Nonnull final String filter,
+            final Object[] filterArgs, final String[] attributeNames, @Nonnull final LdapEntryMapper mapper)
+            throws DataAccessException {
+        try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(base, filter, filterArgs, attributeNames, mapper)) {
             return searchEnum.hasMore() ? searchEnum.next() : null;
         } catch (NamingException e) {
             throw new LdapDataAccessException("Unable to get first element", e);
@@ -77,21 +81,21 @@ public class LDAPExtendedTemplate extends LdapTemplate {
      * Performs a search using the specified filter and returns a List of all matching entries
      * using the given {@link LdapEntryMapper} to convert each entry into a result.
      *
-     * @param base the DN to search in.
-     * @param filter the search filter to use.
-     * @param params the parameters to substitute in the search filter.
+     * @param base the DN to search in. Must not be null.
+     * @param filter the search filter to use. Must not be null.
+     * @param filterArgs the arguments to substitute into the search filter. Passing null is equivalent to an empty array.
      * @param attributeNames the attributes whose values will be retrieved. Passing null returns all attributes.
-     * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values.
+     * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values. Must not be null.
      *
      * @return a List of matching entries converted using the specified {@link LdapEntryMapper}.
      *
      * @see LdapTemplate#searchForSingleEntry
      */
-    public @Nonnull List<? extends Object> searchForAllEntries(final String base, final String filter,
-            final Object[] params, final String[] attributeNames, final LdapEntryMapper mapper)
+    public @Nonnull List<? extends Object> searchForAllEntries(@Nonnull final String base, @Nonnull final String filter,
+            final Object[] filterArgs, final String[] attributeNames, @Nonnull final LdapEntryMapper mapper)
             throws DataAccessException {
         List<Object> results = new ArrayList<>();
-        try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(base, filter, params, attributeNames, mapper)) {
+        try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(base, filter, filterArgs, attributeNames, mapper)) {
             while (searchEnum.hasMore()) {
                 results.add(searchEnum.next());
             }
@@ -101,33 +105,46 @@ public class LDAPExtendedTemplate extends LdapTemplate {
         return results;
     }
 
-    private @Nonnull SearchResultEnumeration searchForAllEntriesEnum(final String base,
-            final String filter, final Object[] params, final String[] attributeNames, final LdapEntryMapper mapper)
+    private @Nonnull SearchResultEnumeration searchForAllEntriesEnum(@Nonnull final String base, @Nonnull final String filter,
+            final Object[] params, final String[] attributeNames, @Nonnull final LdapEntryMapper mapper)
             throws DataAccessException {
-        return (SearchResultEnumeration)execute(new LdapCallback() {
-            @Override
-            public SearchResultEnumeration doInDirContext(DirContext ctx) throws NamingException {
-                SearchControls controls = new SearchControls();
-                controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
-                controls.setReturningAttributes(attributeNames);
-                NamingEnumeration searchResults = ctx.search(base, filter, params, controls);
-                return new SearchResultEnumeration(searchResults, base, ctx.getNameInNamespace(), mapper);
-            }
-        });
+        try {
+            return (SearchResultEnumeration)execute(new LdapCallback() {
+                @Override
+                public SearchResultEnumeration doInDirContext(DirContext ctx) throws NamingException {
+                    SearchControls controls = new SearchControls();
+                    controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+                    controls.setReturningAttributes(attributeNames);
+                    NamingEnumeration searchResults = ctx.search(base, filter, params, controls);
+                    return new SearchResultEnumeration(searchResults, mapper, getDnSuffix(base, ctx.getNameInNamespace()));
+                }
+            });
+        } catch (AuthenticationException e) {
+            throw new LdapDataAccessException("Failed to search LDAP", e);
+        }
+    }
+
+    private String getDnSuffix(String base, String nameInNamespace) {
+        StringBuilder suffix = new StringBuilder();
+        if (!StringUtils.isEmpty(base)) {
+            suffix.append(",").append(base);
+        }
+        if (!StringUtils.isEmpty(nameInNamespace)) {
+            suffix.append(",").append(nameInNamespace);
+        }
+        return suffix.toString();
     }
 
     private static final class SearchResultEnumeration implements AutoCloseable, NamingEnumeration {
 
         private final NamingEnumeration searchResults;
-        private final String base;
-        private final String nameInNamespace;
         private final LdapEntryMapper mapper;
+        private final String dnSuffix;
 
-        public SearchResultEnumeration(NamingEnumeration searchResults, String base, String nameInNamespace, LdapEntryMapper mapper) {
+        public SearchResultEnumeration(NamingEnumeration searchResults, LdapEntryMapper mapper, String dnSuffix) {
             this.searchResults = searchResults;
-            this.base = base;
-            this.nameInNamespace = nameInNamespace;
             this.mapper = mapper;
+            this.dnSuffix = dnSuffix;
         }
 
         @Override
@@ -143,20 +160,7 @@ public class LDAPExtendedTemplate extends LdapTemplate {
         @Override
         public Object next() throws NamingException {
             SearchResult searchResult = (SearchResult) searchResults.next();
-            // Work out the DN of the matched entry
-            StringBuilder dn = new StringBuilder(searchResult.getName());
-
-            if (base.length() > 0) {
-                dn.append(",");
-                dn.append(base);
-            }
-
-            if (org.springframework.util.StringUtils.hasLength(nameInNamespace)) {
-                dn.append(",");
-                dn.append(nameInNamespace);
-            }
-
-            return mapper.mapAttributes(dn.toString(), searchResult.getAttributes());
+            return mapper.mapAttributes(searchResult.getName() + dnSuffix, searchResult.getAttributes());
         }
 
         @Override

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPExtendedTemplate.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPExtendedTemplate.java
@@ -58,14 +58,15 @@ public class LDAPExtendedTemplate extends LdapTemplate {
      * @param attributeNames the attributes whose values will be retrieved. Passing null returns all attributes.
      * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values.
      *
-     * @return the first matching entry converted using the specified {@link LdapEntryMapper}.
+     * @return the first matching entry converted using the specified {@link LdapEntryMapper}, or null if no matching
+     * entry was found.
      *
      * @see LdapTemplate#searchForSingleEntry
      */
     public Object searchForFirstEntry(final String base, final String filter, final Object[] params,
             final String[] attributeNames, final LdapEntryMapper mapper) throws DataAccessException {
         try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(base, filter, params, attributeNames, mapper)) {
-            return searchEnum.next();
+            return searchEnum.hasMore() ? searchEnum.next() : null;
         } catch (NamingException e) {
             throw new LdapDataAccessException("Unable to get first element", e);
         }

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPExtendedTemplate.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPExtendedTemplate.java
@@ -24,14 +24,6 @@
 
 package jenkins.security.plugins.ldap;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.DirContext;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
 import org.acegisecurity.ldap.InitialDirContextFactory;
 import org.acegisecurity.ldap.LdapCallback;
 import org.acegisecurity.ldap.LdapDataAccessException;
@@ -40,6 +32,15 @@ import org.acegisecurity.ldap.LdapTemplate;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.springframework.dao.DataAccessException;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
 
 @Restricted(NoExternalUse.class)
 public class LDAPExtendedTemplate extends LdapTemplate {

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
@@ -24,11 +24,12 @@
 package jenkins.security.plugins.ldap;
 
 import hudson.model.AbstractDescribableImpl;
-import java.util.Set;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.ldap.LdapAuthoritiesPopulator;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
 import org.springframework.dao.DataAccessException;
+
+import java.util.Set;
 
 /**
  * A strategy for determining the groups that a user belongs to.

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
@@ -24,9 +24,13 @@
 package jenkins.security.plugins.ldap;
 
 import hudson.model.AbstractDescribableImpl;
+import java.util.Set;
+import javax.annotation.CheckForNull;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.ldap.LdapAuthoritiesPopulator;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
+import org.springframework.dao.DataAccessException;
 
 /**
  * A strategy for determining the groups that a user belongs to.
@@ -64,4 +68,15 @@ public abstract class LDAPGroupMembershipStrategy extends AbstractDescribableImp
      * @return the {@link GrantedAuthority}s that the specified user belongs to.
      */
     public abstract GrantedAuthority[] getGrantedAuthorities(LdapUserDetails ldapUser);
+
+    /**
+     * Returns a {@link Set} of all members in the specified group.
+     *
+     * @param groupDn the DN of the group whose members will be returned.
+     * @param conf the {@link LDAPConfiguration} that controls some search variables.
+     * @return a set of all members in the specified group.
+     * @throws UsernameNotFoundException if a group with the specified DN does not exist.
+     * @throws DataAccessException if there is an error performing the search.
+     */
+    public abstract @CheckForNull Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException;
 }

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
@@ -25,10 +25,8 @@ package jenkins.security.plugins.ldap;
 
 import hudson.model.AbstractDescribableImpl;
 import java.util.Set;
-import javax.annotation.CheckForNull;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.ldap.LdapAuthoritiesPopulator;
-import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.acegisecurity.userdetails.ldap.LdapUserDetails;
 import org.springframework.dao.DataAccessException;
 
@@ -74,9 +72,12 @@ public abstract class LDAPGroupMembershipStrategy extends AbstractDescribableImp
      *
      * @param groupDn the DN of the group whose members will be returned.
      * @param conf the {@link LDAPConfiguration} that controls some search variables.
-     * @return a set of all members in the specified group.
-     * @throws UsernameNotFoundException if a group with the specified DN does not exist.
+     *
+     * @return a set of all members in the specified group, or null if the members could not be found.
      * @throws DataAccessException if there is an error performing the search.
+     * @since 1.18
      */
-    public abstract @CheckForNull Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException;
+    public Set<String> getGroupMembers(String groupDn, LDAPConfiguration conf) throws DataAccessException {
+        return null;
+    }
 }

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPSearchUtils.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPSearchUtils.java
@@ -1,0 +1,176 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.security.plugins.ldap;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import org.acegisecurity.ldap.LdapCallback;
+import org.acegisecurity.ldap.LdapDataAccessException;
+import org.acegisecurity.ldap.LdapEntryMapper;
+import org.acegisecurity.ldap.LdapTemplate;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.springframework.dao.DataAccessException;
+
+@Restricted(NoExternalUse.class)
+public class LDAPSearchUtils {
+
+    /**
+     * Performs a search using the specified filter and returns the first matching entry using the
+     * given {@link LdapEntryMapper} to convert the entry into a result.
+     *
+     * @param template the {@link LdapTemplate} to use.
+     * @param base the DN to search in.
+     * @param filter the search filter to use.
+     * @param params the parameters to substitute in the search filter.
+     * @param attributeNames the attributes whose values will be retrieved. Passing null returns all attributes.
+     * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values.
+     *
+     * @return the first matching entry converted using the specified {@link LdapEntryMapper}.
+     *
+     * @see LdapTemplate#searchForSingleEntry
+     */
+    public static Object searchForFirstEntry(LdapTemplate template, final String base, final String filter,
+            final Object[] params, final String[] attributeNames, final LdapEntryMapper mapper) throws DataAccessException {
+        try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(template, base, filter, params, attributeNames, mapper)) {
+            return searchEnum.next();
+        } catch (NamingException e) {
+            throw new LdapDataAccessException("Unable to get first element", e);
+        }
+    }
+
+    /**
+     * Performs a search using the specified filter and returns a List of all matching entries
+     * using the given {@link LdapEntryMapper} to convert each entry into a result.
+     *
+     * @param template the {@link LdapTemplate} to use.
+     * @param base the DN to search in.
+     * @param filter the search filter to use.
+     * @param params the parameters to substitute in the search filter.
+     * @param attributeNames the attributes whose values will be retrieved. Passing null returns all attributes.
+     * @param mapper the {@link LdapEntryMapper} that will convert the search results into returned values.
+     *
+     * @return a List of matching entries converted using the specified {@link LdapEntryMapper}.
+     *
+     * @see LdapTemplate#searchForSingleEntry
+     */
+    public static @Nonnull List<? extends Object> searchForAllEntries(LdapTemplate template, final String base,
+            final String filter, final Object[] params, final String[] attributeNames, final LdapEntryMapper mapper)
+            throws DataAccessException {
+        List<Object> results = new ArrayList<>();
+        try (SearchResultEnumeration searchEnum = searchForAllEntriesEnum(template, base, filter, params, attributeNames, mapper)) {
+            while (searchEnum.hasMore()) {
+                results.add(searchEnum.next());
+            }
+        } catch (NamingException e) {
+            throw new LdapDataAccessException("Error processing search results", e);
+        }
+        return results;
+    }
+
+    private static @Nonnull SearchResultEnumeration searchForAllEntriesEnum(LdapTemplate template, final String base,
+            final String filter, final Object[] params, final String[] attributeNames, final LdapEntryMapper mapper)
+            throws DataAccessException {
+        return (SearchResultEnumeration)template.execute(new LdapCallback() {
+            @Override
+            public SearchResultEnumeration doInDirContext(DirContext ctx) throws NamingException {
+                SearchControls controls = new SearchControls();
+                controls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+                controls.setReturningAttributes(attributeNames);
+                NamingEnumeration searchResults = ctx.search(base, filter, params, controls);
+                return new SearchResultEnumeration(searchResults, base, ctx.getNameInNamespace(), mapper);
+            }
+        });
+    }
+
+    private static final class SearchResultEnumeration implements AutoCloseable, NamingEnumeration {
+
+        private final NamingEnumeration searchResults;
+        private final String base;
+        private final String nameInNamespace;
+        private final LdapEntryMapper mapper;
+
+        public SearchResultEnumeration(NamingEnumeration searchResults, String base, String nameInNamespace, LdapEntryMapper mapper) {
+            this.searchResults = searchResults;
+            this.base = base;
+            this.nameInNamespace = nameInNamespace;
+            this.mapper = mapper;
+        }
+
+        @Override
+        public void close() throws NamingException {
+            searchResults.close();
+        }
+
+        @Override
+        public boolean hasMore() throws NamingException {
+            return searchResults.hasMore();
+        }
+
+        @Override
+        public Object next() throws NamingException {
+            SearchResult searchResult = (SearchResult) searchResults.next();
+            // Work out the DN of the matched entry
+            StringBuilder dn = new StringBuilder(searchResult.getName());
+
+            if (base.length() > 0) {
+                dn.append(",");
+                dn.append(base);
+            }
+
+            if (org.springframework.util.StringUtils.hasLength(nameInNamespace)) {
+                dn.append(",");
+                dn.append(nameInNamespace);
+            }
+
+            return mapper.mapAttributes(dn.toString(), searchResult.getAttributes());
+        }
+
+        @Override
+        public boolean hasMoreElements() {
+            try {
+                return hasMore();
+            } catch (NamingException e) {
+                throw new LdapDataAccessException("Unable to check for more elements", e);
+            }
+        }
+
+        @Override
+        public Object nextElement() {
+            try {
+                return next();
+            } catch (NamingException e) {
+                throw new LdapDataAccessException("Unable to get next element", e);
+            }
+        }
+    }
+
+}

--- a/src/test/java/hudson/security/LDAPEmbeddedTest.java
+++ b/src/test/java/hudson/security/LDAPEmbeddedTest.java
@@ -250,7 +250,7 @@ public class LDAPEmbeddedTest {
 
     @Test
     @LDAPSchema(ldif = "sevenSeas", id = "sevenSeas", dn = "o=sevenSeas")
-    public void groupLookupWithMembers() throws Exception {
+    public void groupLookup_membersFromGroupSearch() throws Exception {
         r.jenkins.setSecurityRealm(new LDAPSecurityRealm(
                 ads.getUrl(),
                 null,
@@ -273,6 +273,34 @@ public class LDAPEmbeddedTest {
         GroupDetails groupDetails = r.jenkins.getSecurityRealm().loadGroupByGroupname("HMS Bounty", true);
         assertThat(groupDetails.getDisplayName(), is("HMS Bounty"));
         assertThat(groupDetails.getName(), is("HMS Bounty"));
+        assertThat(groupDetails.getMembers(), containsInAnyOrder("William Bligh", "Fletcher Christian", "John Fryer", "John Hallett"));
+    }
+
+    @Test
+    @LDAPSchema(ldif = "sevenSeas", id = "sevenSeas", dn = "o=sevenSeas")
+    public void groupLookup_membersFromUserRecord() throws Exception {
+        r.jenkins.setSecurityRealm(new LDAPSecurityRealm(
+                ads.getUrl(),
+                null,
+                null,
+                null,
+                null,
+                "(& (cn={0}) (objectclass=simulatedMicrosoftSecurityGroup))",
+                new FromUserRecordLDAPGroupMembershipStrategy("memberOf"),
+                "uid=admin,ou=system",
+                Secret.fromString("pass"),
+                false,
+                false,
+                new LDAPSecurityRealm.CacheConfiguration(100, 1000),
+                new LDAPSecurityRealm.EnvironmentProperty[0],
+                "cn",
+                null,
+                IdStrategy.CASE_INSENSITIVE,
+                IdStrategy.CASE_INSENSITIVE)
+        );
+        GroupDetails groupDetails = r.jenkins.getSecurityRealm().loadGroupByGroupname("HMS_Bounty", true);
+        assertThat(groupDetails.getDisplayName(), is("HMS_Bounty"));
+        assertThat(groupDetails.getName(), is("HMS_Bounty"));
         assertThat(groupDetails.getMembers(), containsInAnyOrder("William Bligh", "Fletcher Christian", "John Fryer", "John Hallett"));
     }
 

--- a/src/test/java/hudson/security/LDAPEmbeddedTest.java
+++ b/src/test/java/hudson/security/LDAPEmbeddedTest.java
@@ -245,7 +245,35 @@ public class LDAPEmbeddedTest {
         GroupDetails groupDetails = r.jenkins.getSecurityRealm().loadGroupByGroupname("HMS Bounty");
         assertThat(groupDetails.getDisplayName(), is("HMS Bounty"));
         assertThat(groupDetails.getName(), is("HMS Bounty"));
-        assertThat("LDAP security realm does not support group member query", groupDetails.getMembers(), nullValue());
+        assertThat("LDAP security realm does not fetch group members by default", groupDetails.getMembers(), nullValue());
+    }
+
+    @Test
+    @LDAPSchema(ldif = "sevenSeas", id = "sevenSeas", dn = "o=sevenSeas")
+    public void groupLookupWithMembers() throws Exception {
+        r.jenkins.setSecurityRealm(new LDAPSecurityRealm(
+                ads.getUrl(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                new FromGroupSearchLDAPGroupMembershipStrategy(null),
+                "uid=admin,ou=system",
+                Secret.fromString("pass"),
+                false,
+                false,
+                new LDAPSecurityRealm.CacheConfiguration(100, 1000),
+                new LDAPSecurityRealm.EnvironmentProperty[0],
+                "cn",
+                null,
+                IdStrategy.CASE_INSENSITIVE,
+                IdStrategy.CASE_INSENSITIVE)
+        );
+        GroupDetails groupDetails = r.jenkins.getSecurityRealm().loadGroupByGroupname("HMS Bounty", true);
+        assertThat(groupDetails.getDisplayName(), is("HMS Bounty"));
+        assertThat(groupDetails.getName(), is("HMS Bounty"));
+        assertThat(groupDetails.getMembers(), containsInAnyOrder("William Bligh", "Fletcher Christian", "John Fryer", "John Hallett"));
     }
 
     @Test

--- a/src/test/java/hudson/security/LdapMultiEmbeddedTest.java
+++ b/src/test/java/hudson/security/LdapMultiEmbeddedTest.java
@@ -293,4 +293,31 @@ public class LdapMultiEmbeddedTest {
         assertThat(log, not(recorded(Level.WARNING,
                 containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER))));
     }
+
+    @Test
+    public void when_second_is_wrong_and_lookup_group_on_second_then_log() throws Exception {
+        setBadPwd(sevenSeas);
+        try {
+            r.jenkins.getSecurityRealm().loadGroupByGroupname("HMS Victory");
+            fail("Expected a DataAccessException");
+        } catch (DataAccessException e) {
+            // Expected.
+        }
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(sevenSeas.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
+    }
+
+    @Test
+    public void when_second_is_wrong_and_lookup_group_on_first_then_no_log() throws Exception {
+        setBadPwd(sevenSeas);
+        try {
+            r.jenkins.getSecurityRealm().loadGroupByGroupname("crew");
+        } catch (DataAccessException e) {
+            fail("No exception should be thrown when first is working");
+        }
+        assertThat(log, not(recorded(Level.WARNING,
+                containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER))));
+    }
 }

--- a/src/test/java/jenkins/security/plugins/ldap/LDAPExtendedTemplateTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/LDAPExtendedTemplateTest.java
@@ -91,8 +91,8 @@ public class LDAPExtendedTemplateTest {
                 new String[]{"cn=HMS_Lydia,ou=crews,ou=groups,o=sevenSeas"}, null, new DnEntryMapper());
         assertThat(matchingEntries, containsInAnyOrder(
                 "cn=Horatio Hornblower,ou=people,o=sevenSeas",
-                "cn=William Bush,ou=people,o=sevenSeas", 
-                "cn=Thomas Quist,ou=people,o=sevenSeas", 
+                "cn=William Bush,ou=people,o=sevenSeas",
+                "cn=Thomas Quist,ou=people,o=sevenSeas",
                 "cn=Moultrie Crystal,ou=people,o=sevenSeas"));
     }
 

--- a/src/test/java/jenkins/security/plugins/ldap/LDAPExtendedTemplateTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/LDAPExtendedTemplateTest.java
@@ -26,9 +26,6 @@ package jenkins.security.plugins.ldap;
 import hudson.security.LDAPSecurityRealm;
 import hudson.security.LDAPSecurityRealm.CacheConfiguration;
 import hudson.util.Secret;
-import java.util.Arrays;
-import java.util.List;
-import javax.naming.directory.Attributes;
 import jenkins.model.IdStrategy;
 import org.acegisecurity.ldap.LdapEntryMapper;
 import org.junit.Test;
@@ -36,6 +33,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.naming.directory.Attributes;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;

--- a/src/test/java/jenkins/security/plugins/ldap/LDAPExtendedTemplateTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/LDAPExtendedTemplateTest.java
@@ -1,0 +1,113 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package jenkins.security.plugins.ldap;
+
+import hudson.security.LDAPSecurityRealm;
+import hudson.security.LDAPSecurityRealm.CacheConfiguration;
+import hudson.util.Secret;
+import java.util.Arrays;
+import java.util.List;
+import javax.naming.directory.Attributes;
+import jenkins.model.IdStrategy;
+import org.acegisecurity.ldap.LdapEntryMapper;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+@LDAPTestConfiguration
+public class LDAPExtendedTemplateTest {
+
+    public LDAPRule ads = new LDAPRule();
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(ads).around(r);
+
+    public LDAPExtendedTemplate template;
+
+    @Before
+    public void setup() throws Exception {
+        ads.loadSchema("sevenSeas", "o=sevenSeas", getClass().getResourceAsStream("/hudson/security/sevenSeas.ldif"));
+        LDAPConfiguration conf = new LDAPConfiguration(
+                ads.getUrl(),
+                null,
+                false,
+                "uid=admin,ou=system", Secret.fromString("pass"));
+        LDAPSecurityRealm realm = new LDAPSecurityRealm(
+                Arrays.asList(conf),
+                false,
+                new CacheConfiguration(100, 100),
+                IdStrategy.CASE_INSENSITIVE,
+                IdStrategy.CASE_INSENSITIVE);
+        r.jenkins.setSecurityRealm(realm);
+        template = conf.getLdapTemplate();
+    }
+
+    @Test
+    public void searchForFirstEntry() throws Exception {
+        String matchingDn = (String)template.searchForFirstEntry("", "(cn={0})", new String[]{"Horatio Hornblower"},
+                null, new DnEntryMapper());
+        assertThat(matchingDn, is("cn=Horatio Hornblower,ou=people,o=sevenSeas"));
+    }
+
+    @Test
+    public void searchForFirstEntry_noMatch() throws Exception {
+        String matchingDn = (String)template.searchForFirstEntry("", "(cn={0})", new String[]{"does not exist"}, null,
+                new DnEntryMapper());
+        assertThat(matchingDn, nullValue());
+    }
+
+    @Test
+    public void searchForAllEntries() throws Exception {
+        List<String> matchingEntries = (List)template.searchForAllEntries("", "(memberOf={0})",
+                new String[]{"cn=HMS_Lydia,ou=crews,ou=groups,o=sevenSeas"}, null, new DnEntryMapper());
+        assertThat(matchingEntries, containsInAnyOrder(
+                "cn=Horatio Hornblower,ou=people,o=sevenSeas",
+                "cn=William Bush,ou=people,o=sevenSeas", 
+                "cn=Thomas Quist,ou=people,o=sevenSeas", 
+                "cn=Moultrie Crystal,ou=people,o=sevenSeas"));
+    }
+
+    @Test
+    public void searchForAllEntries_noMatch() throws Exception {
+        List<String> matchingEntries = (List)template.searchForAllEntries("", "(memberOf={0})",
+                new String[]{"does not exist"}, null, new DnEntryMapper());
+        assertThat(matchingEntries, empty());
+    }
+
+    private static class DnEntryMapper implements LdapEntryMapper {
+        @Override
+        public Object mapAttributes(String dn, Attributes attributes) {
+            return dn;
+        }
+    }
+
+}


### PR DESCRIPTION
See [JENKINS-21784](https://issues.jenkins-ci.org/browse/JENKINS-21784).

Adds support for `SecurityRealm#loadGroupByGroupname(String, boolean)` and `GroupDetails#getMembers()`.

@reviewbybees 