### PR TITLE
[JENKINS-47934] Upgrade the baseline for ldap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <apacheds.version>2.0.0-M23</apacheds.version>
     <apacheds.jdbm.version>2.0.0-M3</apacheds.jdbm.version>
     <jenkins.version>2.16</jenkins.version>
+    <jenkins-test-harness.version>2.32</jenkins-test-harness.version>
   </properties>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <apacheds.version>2.0.0-M23</apacheds.version>
     <apacheds.jdbm.version>2.0.0-M3</apacheds.jdbm.version>
-    <jenkins.version>1.651.3</jenkins.version>
+    <jenkins.version>2.16</jenkins.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
See [JENKINS-47934](https://issues.jenkins-ci.org/browse/JENKINS-47934)

Latest bouncycastle-api-plugin requires Jenkins >= `2.16`

@reviewbybees 