### PR TITLE
Set the compatibleSinceVersion flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,8 +270,11 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <compatibleSinceVersion>1.16</compatibleSinceVersion>
+        </configuration>
       </plugin>
-    </plugins>    
+    </plugins>
   </build>
 
 </project>


### PR DESCRIPTION
Version 1.16 introduced a change ([JENKINS-21475](https://issues.jenkins-ci.org/browse/JENKINS-21475)) in the configuration file which is not backward compatible in terms of plugin downgrades. Although plugin downgrades are not usually supported and not granted to work, additions to the config file are just ignored and old features still work, but not in this case, because there is a structure change in the file which makes older plugin versions unable to know what to load from disk.

The compat warning message says: 
```
Warning: [...] and/or you may not be able to cleanly revert to the prior version without manually restoring old settings [...]
``` 
So I think changes for JENKINS-21475 justify the need of the `compatibleSinceVersion` flag here.

@reviewbybees esp. @rsandell @stephenc (who worked on the change)