### PR TITLE
[JENKINS-48917] Add option to ignore LDAP servers if they are unavailable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /.project
 /.settings
 /.classpath
+/nbproject
+.DS_Store

--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -885,8 +885,11 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             String searchBase = conf.getGroupSearchBase() != null ? conf.getGroupSearchBase() : "";
             String searchFilter = conf.getGroupSearchFilter() != null ? conf.getGroupSearchFilter() : GROUP_SEARCH;
             groups.addAll(conf.getLdapTemplate().searchForSingleAttributeValues(searchBase, searchFilter, new String[]{groupname}, "cn"));
+            // Make sure we don't throw BadCredentialsException. Catch logic matches LDAPUserDetailsService#loadUserByUsername.
             } catch (DataAccessException e) {
                 throwUnlessConfigIsIgnorable(e, conf);
+            } catch (RuntimeException e) {
+                throwUnlessConfigIsIgnorable(new LdapDataAccessException("Failed to search LDAP for group: " + groupname, e), conf);
             }
         }
         return groups;

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
@@ -131,6 +131,12 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
     private final Secret managerPasswordSecret;
     private String displayNameAttributeName;
     private String mailAddressAttributeName;
+    /**
+     * If true, then any operation using this configuration which fails to connect to the server will try
+     * again using the next configuration. This could be a security issue if the same username exists in
+     * multiple LDAP configurations but should not correspond to the same Jenkins user, so it defaults to false.
+     */
+    private boolean ignoreIfUnavailable;
     private Map<String,String> extraEnvVars;
     /**
      * Set in {@link #createApplicationContext(LDAPSecurityRealm, boolean)}
@@ -330,6 +336,15 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
     @DataBoundSetter
     public void setMailAddressAttributeName(String mailAddressAttributeName) {
         this.mailAddressAttributeName = mailAddressAttributeName;
+    }
+
+    public boolean isIgnoreIfUnavailable() {
+        return ignoreIfUnavailable;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreIfUnavailable(boolean ignoreIfUnavailable) {
+        this.ignoreIfUnavailable = ignoreIfUnavailable;
     }
 
     public Map<String,String> getExtraEnvVars() {

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
@@ -47,5 +47,8 @@
                 </f:entry>
             </f:repeatableProperty>
         </f:entry>
+        <f:entry field="ignoreIfUnavailable">
+            <f:checkbox title="${%Ignore if Unavailable}"/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
@@ -47,8 +47,8 @@
                 </f:entry>
             </f:repeatableProperty>
         </f:entry>
-        <f:entry field="ignoreIfUnavailable">
-            <f:checkbox title="${%Ignore if Unavailable}"/>
+        <f:entry field="ignoreIfUnavailable" title="${%Ignore if Unavailable}">
+            <f:checkbox />
         </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-ignoreIfUnavailable.html
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-ignoreIfUnavailable.html
@@ -1,11 +1,18 @@
 <div>
     <p>
     If checked, this option indicates that authentication and user/group membership lookups
-    will be attempted against subsequent LDAP domains even if this domain is unavailable.
+    which fail due to communication errors (e.g., LDAP server is unreachable, manager password is
+    incorrect) will be reattempted using the next configuration. Other types of failures, such as
+    a user attempting to authenticate with an incorrect password, will not be reattempted.
+    </p>
     <p>
-    If unchecked (the default), authentication and user/group memberships for users in
-    subsequent LDAP domains will fail if this domain is unavailable.
+    If unchecked (the default), authentication and user/group membership lookups which fail due to
+    communication errors will not be reattempted using the next configuration.
+    </p>
     <p>
-    The latter is useful when there is a concern that the same username may exist
-    across domains and should not map to the same Jenkins user.
+    The default is intended to prevent users or groups with the same name in distinct LDAP domains
+    from being inadvertently mapped to the same user or group in Jenkins if one of the domains is
+    unavailable. Consequently, this option should only be enabled if all configured domains have
+    distinct user and group names.
+    </p>
 </div>

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-ignoreIfUnavailable.html
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-ignoreIfUnavailable.html
@@ -1,0 +1,11 @@
+<div>
+    <p>
+    If checked, this option indicates that authentication and user/group membership lookups
+    will be attempted against subsequent LDAP domains even if this domain is unavailable.
+    <p>
+    If unchecked (the default), authentication and user/group memberships for users in
+    subsequent LDAP domains will fail if this domain is unavailable.
+    <p>
+    The latter is useful when there is a concern that the same username may exist
+    across domains and should not map to the same Jenkins user.
+</div>

--- a/src/test/java/hudson/security/LDAPSecurityRealmTest.java
+++ b/src/test/java/hudson/security/LDAPSecurityRealmTest.java
@@ -275,6 +275,7 @@ public class LDAPSecurityRealmTest {
             TestConf conf = confs[i];
             final LDAPConfiguration configuration = new LDAPConfiguration(conf.server, conf.rootDN, false, conf.managerDN, Secret.fromString(conf.managerSecret));
             configuration.setUserSearchBase(conf.userSearchBase);
+            configuration.setIgnoreIfUnavailable(i % 2 == 0);
             ldapConfigurations.add(configuration);
         }
         final LDAPSecurityRealm realm = new LDAPSecurityRealm(ldapConfigurations,
@@ -301,6 +302,7 @@ public class LDAPSecurityRealmTest {
             assertEquals(LDAPSecurityRealm.DescriptorImpl.DEFAULT_USER_SEARCH, config.getUserSearch());
             assertEquals(LDAPSecurityRealm.DescriptorImpl.DEFAULT_DISPLAYNAME_ATTRIBUTE_NAME, config.getDisplayNameAttributeName());
             assertEquals(LDAPSecurityRealm.DescriptorImpl.DEFAULT_MAILADDRESS_ATTRIBUTE_NAME, config.getMailAddressAttributeName());
+            assertEquals(i % 2 == 0, config.isIgnoreIfUnavailable());
         }
         assertThat(newRealm.getUserIdStrategy(), instanceOf(IdStrategy.CaseInsensitive.class));
     }

--- a/src/test/java/hudson/security/LdapMultiEmbeddedTest.java
+++ b/src/test/java/hudson/security/LdapMultiEmbeddedTest.java
@@ -17,8 +17,13 @@ import org.springframework.dao.DataAccessException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
+import org.acegisecurity.AuthenticationException;
+import org.acegisecurity.AuthenticationServiceException;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.Matchers.*;
@@ -148,8 +153,18 @@ public class LdapMultiEmbeddedTest {
     }
 
     public static final String FAILED_COMMUNICATION_WITH_LDAP_SERVER = "Failed communication with ldap server";
+    public static final String WILL_NOT_TRY_NEXT_CONFIGURATION = ", will _not_ try the next configuration";
+    public static final String WILL_TRY_NEXT_CONFIGURATION = ", will try the next configuration";
 
     private void setBadPwd(LDAPRule rule) {
+        reconfigure(rule, EnumSet.of(LdapConfigOption.BAD_PASSWORD));
+    }
+
+    private enum LdapConfigOption {
+        BAD_PASSWORD, BAD_SERVER_URL, IGNORE_IF_UNAVAILABLE
+    }
+
+    private void reconfigure(LDAPRule rule, Set<LdapConfigOption> options) {
         final LDAPSecurityRealm realm = (LDAPSecurityRealm)r.jenkins.getSecurityRealm();
         LDAPConfiguration repl = null;
         int index = -1;
@@ -166,11 +181,18 @@ public class LdapMultiEmbeddedTest {
         assertTrue(index >= 0);
 
         LDAPConfiguration nc = new LDAPConfiguration(
-                repl.getServer(),
+                options.contains(LdapConfigOption.BAD_SERVER_URL)
+                        ? "invalid" + repl.getServer()
+                        : repl.getServer(),
                 repl.getRootDN(),
                 true,
                 repl.getManagerDN(),
-                Secret.fromString("something completely wrong"));
+                options.contains(LdapConfigOption.BAD_PASSWORD)
+                        ? Secret.fromString("something completely wrong")
+                        : repl.getManagerPasswordSecret());
+        if (options.contains(LdapConfigOption.IGNORE_IF_UNAVAILABLE)) {
+            nc.setIgnoreIfUnavailable(true);
+        }
         configurations.set(index, nc);
         r.jenkins.setSecurityRealm(new LDAPSecurityRealm(configurations,
                 realm.disableMailAddressResolver,
@@ -244,8 +266,8 @@ public class LdapMultiEmbeddedTest {
             //all is as expected
         }
         assertThat(log, recorded(Level.WARNING,
-                allOf(containsString("LDAP connection"),
-                        containsString("seems to be broken, will _not_ try the next configuration"),
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_NOT_TRY_NEXT_CONFIGURATION),
                         containsString(planetExpress.getUrl())),
                 CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
     }
@@ -260,8 +282,8 @@ public class LdapMultiEmbeddedTest {
             //all is as expected
         }
         assertThat(log, recorded(Level.WARNING,
-                allOf(containsString("LDAP connection"),
-                        containsString("seems to be broken, will _not_ try the next configuration"),
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_NOT_TRY_NEXT_CONFIGURATION),
                         containsString(planetExpress.getUrl())),
                 CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
     }
@@ -276,8 +298,8 @@ public class LdapMultiEmbeddedTest {
             //all is as expected
         }
         assertThat(log, recorded(Level.WARNING,
-                allOf(containsString("LDAP connection"),
-                        containsString("seems to be broken, will _not_ try the next configuration"),
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_NOT_TRY_NEXT_CONFIGURATION),
                         containsString(sevenSeas.getUrl())),
                 CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
     }
@@ -292,5 +314,140 @@ public class LdapMultiEmbeddedTest {
         }
         assertThat(log, not(recorded(Level.WARNING,
                 containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER))));
+    }
+
+    @Test
+    public void when_first_is_ignorable_and_login_with_wrong_password_then_stop() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        try {
+            r.createWebClient().login("fry", "invalid");
+            fail("Login should fail");
+        } catch (FailingHttpStatusCodeException e) {
+            assertEquals(401, e.getStatusCode());
+        }
+        assertThat(log, not(recorded(allOf(
+                containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                containsString(WILL_TRY_NEXT_CONFIGURATION),
+                containsString(planetExpress.getUrl())))));
+    }
+
+    @Test
+    public void when_first_is_unavailable_and_login_on_second_then_no_login() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_SERVER_URL));
+        try {
+            r.createWebClient().login("hnelson", "pass");
+            fail("Login should fail");
+        } catch (FailingHttpStatusCodeException e) {
+            assertEquals(401, e.getStatusCode());
+        }
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_NOT_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(AuthenticationServiceException.class)));
+    }
+
+    @Test
+    public void when_first_is_wrong_and_ignorable_and_login_on_second_then_login() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_PASSWORD, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        r.createWebClient().login("hnelson", "pass");
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
+    }
+
+    @Test
+    public void when_first_is_unavailable_and_ignorable_and_login_on_second_then_login() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_SERVER_URL, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        r.createWebClient().login("hnelson", "pass");
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(AuthenticationServiceException.class)));
+    }
+
+    @Test
+    public void when_first_and_second_are_unavailable_and_ignorable_then_no_login() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_SERVER_URL, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        reconfigure(sevenSeas, EnumSet.of(LdapConfigOption.BAD_SERVER_URL, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        try {
+            r.createWebClient().login("hnelson", "pass");
+            fail("Login should fail");
+        } catch (FailingHttpStatusCodeException e) {
+            assertEquals(401, e.getStatusCode());
+        }
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(AuthenticationServiceException.class)));
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(sevenSeas.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(AuthenticationServiceException.class)));
+    }
+
+    @Test
+    public void when_first_is_unavailable_and_lookup_on_second_then_failure() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_SERVER_URL));
+        try {
+            assertThat(r.jenkins.getSecurityRealm().loadUserByUsername("hnelson"), nullValue());
+            fail("Expected a DataAccessException");
+        } catch (DataAccessException e) {
+            //all is as expected
+        }
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_NOT_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
+    }
+
+    @Test
+    public void when_first_is_wrong_but_ignorable_and_lookup_on_second_then_success() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_PASSWORD, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        assertThat(r.jenkins.getSecurityRealm().loadUserByUsername("hnelson"), notNullValue());
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
+    }
+
+    @Test
+    public void when_first_is_unavailable_but_ignorable_and_lookup_on_second_then_success() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_SERVER_URL, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        assertThat(r.jenkins.getSecurityRealm().loadUserByUsername("hnelson"), notNullValue());
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
+    }
+
+    @Test
+    public void when_first_and_second_are_unavailable_and_ignorable_then_lookup_fails() throws Exception {
+        reconfigure(planetExpress, EnumSet.of(LdapConfigOption.BAD_SERVER_URL, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        reconfigure(sevenSeas, EnumSet.of(LdapConfigOption.BAD_SERVER_URL, LdapConfigOption.IGNORE_IF_UNAVAILABLE));
+        try {
+            r.jenkins.getSecurityRealm().loadUserByUsername("hnelson");
+            fail("Expected a UsernameNotFoundException");
+        } catch (UsernameNotFoundException e) {
+            //all is as expected
+        }
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(planetExpress.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
+        assertThat(log, recorded(Level.WARNING,
+                allOf(containsString(FAILED_COMMUNICATION_WITH_LDAP_SERVER),
+                        containsString(WILL_TRY_NEXT_CONFIGURATION),
+                        containsString(sevenSeas.getUrl())),
+                CoreMatchers.<Throwable>instanceOf(DataAccessException.class)));
     }
 }

--- a/src/test/java/hudson/security/LdapMultiEmbeddedTest.java
+++ b/src/test/java/hudson/security/LdapMultiEmbeddedTest.java
@@ -155,7 +155,7 @@ public class LdapMultiEmbeddedTest {
     public static final String FAILED_COMMUNICATION_WITH_LDAP_SERVER = "Failed communication with ldap server";
     public static final String WILL_NOT_TRY_NEXT_CONFIGURATION = ", will _not_ try the next configuration";
     public static final String WILL_TRY_NEXT_CONFIGURATION = ", will try the next configuration";
-    public static final String INVALID_URL_PREFIX = "ldap://invalid_host_for_testing:"; // TEST-NET-1 as defined by RFC 5737, will not resolve to a real address.
+    public static final String INVALID_URL_PREFIX = "ldap://invalid_host_for_testing:";
 
     private void setBadPwd(LDAPRule rule) {
         reconfigure(rule, EnumSet.of(LdapConfigOption.BAD_PASSWORD));


### PR DESCRIPTION
See [JENKINS-48917](https://issues.jenkins-ci.org/browse/JENKINS-48917).

This change allows communication failures with LDAP servers (i.e., DataAccessException, AuthenticationServiceException) to be ignored so that the failed action will be reattempted with the next configuration.

@reviewbybees 