### PR TITLE
Configuration-as-Code compatibility

### DIFF
--- a/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPGroupMembershipStrategy.java
@@ -23,6 +23,7 @@
  */
 package jenkins.security.plugins.ldap;
 
+import hudson.ExtensionPoint;
 import hudson.model.AbstractDescribableImpl;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.ldap.LdapAuthoritiesPopulator;
@@ -36,7 +37,7 @@ import java.util.Set;
  *
  * @since 1.10
  */
-public abstract class LDAPGroupMembershipStrategy extends AbstractDescribableImpl<LDAPGroupMembershipStrategy> {
+public abstract class LDAPGroupMembershipStrategy extends AbstractDescribableImpl<LDAPGroupMembershipStrategy> implements ExtensionPoint {
     /**
      * The standard group member of searcher.
      */


### PR DESCRIPTION
[JCasC](https://github.com/jenkinsci/configuration-as-code-plugin/pull/392) relies on ExtensionPoint to determine the API implemented by a component and compute it's symbol name (until a `@Symbol` annotation is explicitly set)

see usage [here](https://github.com/ndeloof/configuration-as-code-plugin/commit/e60cc3d10d648acff0ef188bf9fb5763ae4079e8)