### PR TITLE
Add support for using Jenkins credentials store

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,7 @@ jenkins:
       configurations:
         - server: ldap.acme.com
           rootDN: dc=acme,dc=fr
-          managerDN: "manager"
-          managerPasswordSecret: ${LDAP_PASSWORD}
+          credentialsId: "bindDN"
           userSearch: "(&(objectCategory=User)(sAMAccountName={0}))"
           groupSearchFilter: "(&(cn={0})(objectclass=group))"
           groupMembershipStrategy:

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
       <version>1.20</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>2.1.19</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.test</groupId>
       <artifactId>docker-fixtures</artifactId>
       <version>1.8</version>

--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1675,9 +1675,9 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             // we can only do deep validation if the connection is correct
             LDAPConfiguration.LDAPConfigurationDescriptor confDescriptor = Jenkins.getActiveInstance().getDescriptorByType(LDAPConfiguration.LDAPConfigurationDescriptor.class);
             for (LDAPConfiguration configuration : realm.getConfigurations()) {
-                FormValidation connectionCheck = confDescriptor.doCheckServer(configuration.getServerUrl(), configuration.getManagerDN(), configuration.getManagerPasswordSecret());
-                if (connectionCheck.kind != FormValidation.Kind.OK) {
-                    return connectionCheck;
+                FormValidation connnectionCheck = confDescriptor.doCheckServer(configuration.getServerUrl(), configuration.getCredentialsId());
+                if (connnectionCheck.kind != FormValidation.Kind.OK) {
+                    return connnectionCheck;
                 }
             }
 

--- a/src/main/java/jenkins/security/plugins/ldap/CredentialsMigrator.java
+++ b/src/main/java/jenkins/security/plugins/ldap/CredentialsMigrator.java
@@ -1,0 +1,68 @@
+package jenkins.security.plugins.ldap;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.security.ACL;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+final class CredentialsMigrator {
+
+    private CredentialsMigrator() {}
+
+    private static final Logger LOGGER = Logger.getLogger(CredentialsMigrator.class.getName());
+
+    static Optional<StandardCredentials> migrate(String managerDN, Secret managerPasswordSecret) {
+        if(StringUtils.isBlank(managerDN)) {
+            return Optional.empty();
+        }
+        LOGGER.info("Migrating ldap credentials: Moving manager DN and password into the credentials store");
+        List<StandardUsernamePasswordCredentials> allUsernamePasswordCredentials = CredentialsMatchers.filter(
+                CredentialsProvider.lookupCredentials(
+                        StandardUsernamePasswordCredentials.class,
+                        Jenkins.getInstanceOrNull(),
+                        ACL.SYSTEM,
+                        (DomainRequirement) null),
+                CredentialsMatchers.always());
+
+        return Optional.of(allUsernamePasswordCredentials
+                .stream()
+                .filter(cred -> cred.getUsername().equals(managerDN))
+                .filter(cred -> cred.getPassword().equals(managerPasswordSecret))
+                .findAny()
+                .orElseGet(() -> addCredentialsIfNotPresent(managerDN, managerPasswordSecret)));
+    }
+
+    private static StandardUsernamePasswordCredentials addCredentialsIfNotPresent(@Nonnull String managerDN, @Nonnull Secret managerPassword) {
+        StandardUsernamePasswordCredentials credentials = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.SYSTEM,
+                UUID.randomUUID().toString(),
+                "Migrated ldap manager credentials",
+                managerDN,
+                managerPassword.getPlainText());
+
+        SystemCredentialsProvider instance = SystemCredentialsProvider.getInstance();
+        instance.getCredentials().add(credentials);
+        try {
+            instance.save();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        return credentials;
+    }
+}

--- a/src/main/java/jenkins/security/plugins/ldap/CredentialsMigrator.java
+++ b/src/main/java/jenkins/security/plugins/ldap/CredentialsMigrator.java
@@ -30,7 +30,7 @@ final class CredentialsMigrator {
         if(StringUtils.isBlank(managerDN)) {
             return Optional.empty();
         }
-        LOGGER.info("Migrating ldap credentials: Moving manager DN and password into the credentials store");
+        LOGGER.info("Migrating LDAP credentials: Moving manager DN and password into the credentials store");
         List<StandardUsernamePasswordCredentials> allUsernamePasswordCredentials = CredentialsMatchers.filter(
                 CredentialsProvider.lookupCredentials(
                         StandardUsernamePasswordCredentials.class,
@@ -51,7 +51,7 @@ final class CredentialsMigrator {
         StandardUsernamePasswordCredentials credentials = new UsernamePasswordCredentialsImpl(
                 CredentialsScope.SYSTEM,
                 UUID.randomUUID().toString(),
-                "Migrated ldap manager credentials",
+                "Migrated LDAP manager credentials",
                 managerDN,
                 managerPassword.getPlainText());
 

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
@@ -363,6 +363,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
      */
     @CheckForNull
     @Deprecated
+    @Deprecated
     public String getManagerDN() {
         return getCredentials().map(UsernameCredentials::getUsername).orElse(null);
     }
@@ -371,6 +372,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
      * Password used to first bind to LDAP.
      */
     @CheckForNull
+    @Deprecated
     public String getManagerPassword() {
         return getCredentials().map(PasswordCredentials::getPassword).map(Secret::getPlainText).orElse(null);
     }
@@ -378,6 +380,8 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
     /**
      * @deprecated replaced by ${@link #credentialsId}
      */
+    @CheckForNull
+    @Deprecated
     @CheckForNull
     @Deprecated
     public Secret getManagerPasswordSecret() {

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" >
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:c="/lib/credentials"> >
     <f:entry field="server" title="${%Server}">
         <f:textbox/>
     </f:entry>
@@ -25,11 +25,8 @@
         <f:entry field="groupMembershipStrategy" title="${%Group membership}">
             <f:hetero-radio field="groupMembershipStrategy" descriptors="${descriptor.groupMembershipStrategies}"/>
         </f:entry>
-        <f:entry field="managerDN" title="${%Manager DN}">
-            <f:textbox autocomplete="off"/>
-        </f:entry>
-        <f:entry field="managerPasswordSecret" title="${%Manager Password}">
-            <f:password autocomplete="off"/>
+        <f:entry field="credentialsId" title="${%Manager Credentials}">
+            <c:select name="ldap.credentialsId" value="${instance.getCredentialsId()}"/>
         </f:entry>
         <f:entry field="displayNameAttributeName" title="${%Display Name LDAP attribute}">
             <f:textbox default="${descriptor.DEFAULT_DISPLAYNAME_ATTRIBUTE_NAME}"/>

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
@@ -26,7 +26,7 @@
             <f:hetero-radio field="groupMembershipStrategy" descriptors="${descriptor.groupMembershipStrategies}"/>
         </f:entry>
         <f:entry field="credentialsId" title="${%Manager Credentials}">
-            <c:select name="ldap.credentialsId" value="${instance.getCredentialsId()}"/>
+            <c:select name="ldap.credentialsId"/>
         </f:entry>
         <f:entry field="displayNameAttributeName" title="${%Display Name LDAP attribute}">
             <f:textbox default="${descriptor.DEFAULT_DISPLAYNAME_ATTRIBUTE_NAME}"/>

--- a/src/test/java/jenkins/security/plugins/ldap/CasCTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/CasCTest.java
@@ -16,10 +16,8 @@ import static org.junit.Assert.assertTrue;
 // Based on https://github.com/jenkinsci/configuration-as-code-plugin/blob/7766b7ef6153e3e210f257d323244c1f1470a10f/integrations/src/test/java/io/jenkins/plugins/casc/LDAPTest.java
 public class CasCTest {
     @Rule
-    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
-            .set("LDAP_PASSWORD", "SECRET"))
-            .around(new JenkinsConfiguredWithCodeRule());
-    
+    public JenkinsConfiguredWithCodeRule chain = new JenkinsConfiguredWithCodeRule();
+
     @Test
     @ConfiguredWithCode("casc.yml")
     public void configure_ldap() {
@@ -30,8 +28,7 @@ public class CasCTest {
         assertTrue(securityRealm.getGroupIdStrategy() instanceof IdStrategy.CaseSensitive);
         final LDAPConfiguration configuration = securityRealm.getConfigurations().get(0);
         assertEquals("ldap.acme.com", configuration.getServer());
-        assertEquals("SECRET", configuration.getManagerPassword());
-        assertEquals("manager", configuration.getManagerDN());
+        assertEquals("bindCredentials", configuration.getCredentialsId());
         assertEquals("(&(objectCategory=User)(sAMAccountName={0}))", configuration.getUserSearch());
         assertEquals("(&(cn={0})(objectclass=group))", configuration.getGroupSearchFilter());
         final FromGroupSearchLDAPGroupMembershipStrategy strategy = ((FromGroupSearchLDAPGroupMembershipStrategy) configuration.getGroupMembershipStrategy());

--- a/src/test/resources/jenkins/security/plugins/ldap/casc.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/casc.yml
@@ -1,3 +1,5 @@
+configuration-as-code:
+  deprecated: warn
 jenkins:
   securityRealm:
     ldap:

--- a/src/test/resources/jenkins/security/plugins/ldap/casc.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/casc.yml
@@ -1,13 +1,10 @@
-configuration-as-code:
-  deprecated: warn
 jenkins:
   securityRealm:
     ldap:
       configurations:
         - server: ldap.acme.com
           rootDN: dc=acme,dc=fr
-          managerDN: "manager"
-          managerPasswordSecret: ${LDAP_PASSWORD}
+          credentialsId: "bindCredentials"
           userSearch: "(&(objectCategory=User)(sAMAccountName={0}))"
           groupSearchFilter: "(&(cn={0})(objectclass=group))"
           groupMembershipStrategy:


### PR DESCRIPTION
This draft migrates the managerDN and managerPassword to use Jenkins credentials store.

I have not yet added necessary test cases but would like to start the conversation early.
In addition, the documentation still needs to be updated, but I would like to wait with that until the final design has been approved.

I have done manual tests with both a default installation of Jenkins and also with the [Configuration As Code](https://github.com/jenkinsci/configuration-as-code-plugin) plugin installed and it seems to work fine.