### PR TITLE
Configuration as Code compatibility tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ To install:
 2. or use the plugin management console (http://example.com:8080/pluginManager/advanced) to upload the hpi file. You have to restart Jenkins in order to find the pluing in the installed plugins list.
 
 
+Configuration with JCasC
+---------------
+```yaml
+jenkins:
+  securityRealm:
+    ldap:
+      configurations:
+        - server: ldap.acme.com
+          rootDN: dc=acme,dc=fr
+          managerDN: "manager"
+          managerPasswordSecret: ${LDAP_PASSWORD}
+          userSearch: "(&(objectCategory=User)(sAMAccountName={0}))"
+          groupSearchFilter: "(&(cn={0})(objectclass=group))"
+          groupMembershipStrategy:
+            fromGroupSearch:
+              filter: "(&(objectClass=group)(|(cn=GROUP_1)(cn=GROUP_2)))"
+      cache:
+        size: 100
+        ttl: 10
+      userIdStrategy: CaseInsensitive
+      groupIdStrategy: CaseSensitive
+```
+To get more examples, see [yaml files used in tests](src/test/resources/jenkins/security/plugins/ldap)
+
+
 Plugin releases
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To install:
 
 Configuration with JCasC
 ---------------
+
 ```yaml
 jenkins:
   securityRealm:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ jenkins:
 ```
 To get more examples, see [yaml files used in tests](src/test/resources/jenkins/security/plugins/ldap)
 
-
 Plugin releases
 ---------------
 
@@ -84,4 +83,3 @@ License
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
-

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.50</version>
+    <version>3.53</version>
     <relativePath />
   </parent>
 
@@ -27,6 +27,7 @@
     <apacheds.version>2.0.0.AM25</apacheds.version>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
+    <configuration-as-code.version>1.36</configuration-as-code.version>
   </properties>
 
   <scm>
@@ -59,6 +60,13 @@
       <artifactId>docker-fixtures</artifactId>
       <version>1.8</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- Required: 2.2.3, JCasC includes: 2.10.2 -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -234,7 +242,21 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.10.2</version>
+      <version>1.11.3</version>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${configuration-as-code.version}</version>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>${configuration-as-code.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/jenkins/security/plugins/ldap/CasCTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/CasCTest.java
@@ -1,0 +1,40 @@
+package jenkins.security.plugins.ldap;
+
+import hudson.security.LDAPSecurityRealm;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.IdStrategy;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.RuleChain;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// Based on https://github.com/jenkinsci/configuration-as-code-plugin/blob/7766b7ef6153e3e210f257d323244c1f1470a10f/integrations/src/test/java/io/jenkins/plugins/casc/LDAPTest.java
+public class CasCTest {
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
+            .set("LDAP_PASSWORD", "SECRET"))
+            .around(new JenkinsConfiguredWithCodeRule());
+    
+    @Test
+    @ConfiguredWithCode("casc.yml")
+    public void configure_ldap() {
+        final Jenkins jenkins = Jenkins.getInstance();
+        final LDAPSecurityRealm securityRealm = (LDAPSecurityRealm) jenkins.getSecurityRealm();
+        assertEquals(1, securityRealm.getConfigurations().size());
+        assertTrue(securityRealm.getUserIdStrategy() instanceof IdStrategy.CaseInsensitive);
+        assertTrue(securityRealm.getGroupIdStrategy() instanceof IdStrategy.CaseSensitive);
+        final LDAPConfiguration configuration = securityRealm.getConfigurations().get(0);
+        assertEquals("ldap.acme.com", configuration.getServer());
+        assertEquals("SECRET", configuration.getManagerPassword());
+        assertEquals("manager", configuration.getManagerDN());
+        assertEquals("(&(objectCategory=User)(sAMAccountName={0}))", configuration.getUserSearch());
+        assertEquals("(&(cn={0})(objectclass=group))", configuration.getGroupSearchFilter());
+        final FromGroupSearchLDAPGroupMembershipStrategy strategy = ((FromGroupSearchLDAPGroupMembershipStrategy) configuration.getGroupMembershipStrategy());
+        assertEquals("(&(objectClass=group)(|(cn=GROUP_1)(cn=GROUP_2)))", strategy.getFilter());
+    }
+}

--- a/src/test/java/jenkins/security/plugins/ldap/CascSecurityRealmTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/CascSecurityRealmTest.java
@@ -1,0 +1,35 @@
+package jenkins.security.plugins.ldap;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static io.jenkins.plugins.casc.misc.Util.getJenkinsRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+// Based on https://github.com/jenkinsci/configuration-as-code-plugin/blob/7766b7ef6153e3e210f257d323244c1f1470a10f/integrations/src/test/java/io/jenkins/plugins/casc/LDAPSecurityRealmTest.java
+public class CascSecurityRealmTest {
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("LDAPSecurityRealmTestNoSecret.yml")
+    public void export_ldap_no_secret() throws Exception {
+        ConfiguratorRegistry registry = ConfiguratorRegistry.get();
+        ConfigurationContext context = new ConfigurationContext(registry);
+        CNode yourAttribute = getJenkinsRoot(context).get("securityRealm").asMapping().get("ldap");
+
+        String exported = toYamlString(yourAttribute);
+
+        String expected = toStringFromYamlFile(this, "LDAPSecurityRealmTestNoSecretExpected.yml");
+
+        assertThat(exported, is(expected));
+    }
+}

--- a/src/test/resources/jenkins/security/plugins/ldap/LDAPSecurityRealmTestNoSecret.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/LDAPSecurityRealmTestNoSecret.yml
@@ -1,0 +1,11 @@
+jenkins:
+  securityRealm:
+    ldap:
+      configurations:
+        - server: ldap.acme.com
+          rootDN: dc=acme,dc=fr
+      cache:
+        size: 100
+        ttl: 10
+      userIdStrategy: CaseInsensitive
+      groupIdStrategy: CaseSensitive

--- a/src/test/resources/jenkins/security/plugins/ldap/LDAPSecurityRealmTestNoSecretExpected.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/LDAPSecurityRealmTestNoSecretExpected.yml
@@ -1,0 +1,10 @@
+cache:
+  size: 100
+  ttl: 30
+configurations:
+- inhibitInferRootDN: false
+  rootDN: "dc=acme,dc=fr"
+  server: "ldap.acme.com"
+disableMailAddressResolver: false
+groupIdStrategy: "caseSensitive"
+userIdStrategy: "caseInsensitive"

--- a/src/test/resources/jenkins/security/plugins/ldap/casc.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/casc.yml
@@ -1,0 +1,18 @@
+jenkins:
+  securityRealm:
+    ldap:
+      configurations:
+        - server: ldap.acme.com
+          rootDN: dc=acme,dc=fr
+          managerDN: "manager"
+          managerPasswordSecret: ${LDAP_PASSWORD}
+          userSearch: "(&(objectCategory=User)(sAMAccountName={0}))"
+          groupSearchFilter: "(&(cn={0})(objectclass=group))"
+          groupMembershipStrategy:
+            fromGroupSearch:
+              filter: "(&(objectClass=group)(|(cn=GROUP_1)(cn=GROUP_2)))"
+      cache:
+        size: 100
+        ttl: 10
+      userIdStrategy: CaseInsensitive
+      groupIdStrategy: CaseSensitive


### PR DESCRIPTION
I've added to the plugin the tests already done on [Configuration as Code plugin](https://github.com/jenkinsci/configuration-as-code-plugin) to test the JCasC compatibility on each release.

I've added some documentation on how to configure the plugin with CasC.

@rsandell @varyvol @alecharp @batmat 