### PR TITLE
[JENKINS-61854] Fix ldap test button dialog on Jenkins > 2.214

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -39,6 +39,7 @@ import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Scrambler;
 import hudson.util.Secret;
+import hudson.util.VersionNumber;
 import jenkins.model.IdStrategy;
 import jenkins.model.Jenkins;
 import jenkins.security.plugins.ldap.FromGroupSearchLDAPGroupMembershipStrategy;
@@ -1599,6 +1600,19 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
 
         public boolean hasCustomBindScript() {
             return LDAPConfiguration.getLdapBindOverrideFile(Jenkins.getActiveInstance()).exists();
+        }
+
+        /**
+         * Used by config.jelly to determine whether we are running on a Jenkins with Enable Security checkbox or not.
+         * It impacts the json structure to send when checking the ldap configuration in the filter attribute of the
+         * validate element
+         * @return true if this Jenkins has Enable Security checkbox
+         */
+        public boolean hasEnableSecurityForm() {
+            // make spotbugs happy and if the version is not computed, we assume we are on a modern version, without
+            // the enable security form
+            VersionNumber currentVersion = Jenkins.getVersion();
+            return currentVersion != null && currentVersion.isOlderThan(new VersionNumber("2.214"));
         }
 
         @RequirePOST

--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1608,6 +1608,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
          * validate element
          * @return true if this Jenkins has Enable Security checkbox
          */
+        @Restricted(NoExternalUse.class)
         public boolean hasEnableSecurityForm() {
             // make spotbugs happy and if the version is not computed, we assume we are on a modern version, without
             // the enable security form

--- a/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
+++ b/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
@@ -44,7 +44,16 @@ THE SOFTWARE.
             </table>
         </f:repeatable>
     </f:entry>
-    <v:validate name="validateLdapSettings" method="validate" filter="useSecurity.realm"
+    <j:choose>
+        <j:when test="${descriptor.hasEnableSecurityForm()}">
+            <j:set var="validateFilter" value="useSecurity.realm" />
+        </j:when>
+        <j:otherwise>
+            <j:set var="validateFilter" value="realm" />
+        </j:otherwise>
+    </j:choose>
+    
+    <v:validate name="validateLdapSettings" method="validate" filter="${validateFilter}"
                 title="${%Test LDAP settings}"
                 dialog="${%Test LDAP settings}"
                 submit="${%Test}">


### PR DESCRIPTION
See [JENKINS-61854](https://issues.jenkins-ci.org/browse/JENKINS-61854)

The dialog shown when pressing the **_Test LDAP Settings_** button of the ldap configuration was broken after Jenkins 2.214 because the check **_Enable Security_** was removed and the javascript was not working.

I've added a decision logic for Jenkins < 2.214 or >= 2.214

Tested manually with:
* `mvn hpi:run -Djenkins.version=2.230` (2.230) and
* `mvn hpi:run` (2.60.3)