### PR TITLE
[JENKINS-61854] Get the json value depending on the Jenkins version

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1626,7 +1626,13 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             JSONObject json = JSONObject.fromObject(IOUtils.toString(req.getInputStream()));
             String user = json.getString("testUser");
             String password = json.getString("testPassword");
-            JSONObject realmCfg = json.getJSONObject("useSecurity").getJSONObject("realm");
+            JSONObject realmCfg;
+            if (hasEnableSecurityForm()) {
+                realmCfg = json.getJSONObject("useSecurity").getJSONObject("realm");    
+            } else {
+                realmCfg = json.getJSONObject("realm");
+            }
+            
             // instantiate the realm
             LDAPSecurityRealm realm = req.bindJSON(LDAPSecurityRealm.class, realmCfg);
             return validate(realm, user, password);

--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1628,7 +1628,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             String password = json.getString("testPassword");
             JSONObject realmCfg;
             if (hasEnableSecurityForm()) {
-                realmCfg = json.getJSONObject("useSecurity").getJSONObject("realm");    
+                realmCfg = json.getJSONObject("useSecurity").getJSONObject("realm");
             } else {
                 realmCfg = json.getJSONObject("realm");
             }


### PR DESCRIPTION
My previous fix wasn't enough. On java code it's also needed to get the correct element from the json based on the Jenkins version.

![Screenshot from 2020-04-21 18-33-29](https://user-images.githubusercontent.com/22069922/79889790-cf3c7880-83fe-11ea-8bb0-dbbf764c18f4.png)

Now I managed to configure a ldap server with all needed and all checks are green. 