### PR TITLE
Suppress Dockerized tests on Windows

### DIFF
--- a/src/test/java/hudson/security/docker/MultiServerTest.java
+++ b/src/test/java/hudson/security/docker/MultiServerTest.java
@@ -1,5 +1,6 @@
 package hudson.security.docker;
 
+import hudson.Functions;
 import hudson.model.User;
 import hudson.security.LDAPEmbeddedTest;
 import hudson.security.LDAPSecurityRealm;
@@ -23,12 +24,19 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import org.junit.BeforeClass;
 
 /**
  * Tests connecting to two different servers
  */
 @LDAPTestConfiguration
 public class MultiServerTest {
+
+    @BeforeClass public static void linuxOnly() {
+        assumeFalse("Windows CI builders now have Docker installed…but it does not support Linux images", Functions.isWindows());
+    }
+
     @Rule
     public DockerRule<PlanetExpressTest.PlanetExpress> docker = new DockerRule<>(PlanetExpressTest.PlanetExpress.class);
     public JenkinsRule j = new JenkinsRule();

--- a/src/test/java/hudson/security/docker/MultiServerTest.java
+++ b/src/test/java/hudson/security/docker/MultiServerTest.java
@@ -1,6 +1,5 @@
 package hudson.security.docker;
 
-import hudson.Functions;
 import hudson.model.User;
 import hudson.security.LDAPEmbeddedTest;
 import hudson.security.LDAPSecurityRealm;
@@ -24,7 +23,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeFalse;
 import org.junit.BeforeClass;
 
 /**
@@ -34,7 +32,7 @@ import org.junit.BeforeClass;
 public class MultiServerTest {
 
     @BeforeClass public static void linuxOnly() {
-        assumeFalse("Windows CI builders now have Docker installed…but it does not support Linux images", Functions.isWindows());
+        PlanetExpressTest.linuxOnly();
     }
 
     @Rule

--- a/src/test/java/hudson/security/docker/PlanetExpressTest.java
+++ b/src/test/java/hudson/security/docker/PlanetExpressTest.java
@@ -1,5 +1,6 @@
 package hudson.security.docker;
 
+import hudson.Functions;
 import hudson.security.LDAPSecurityRealm;
 import hudson.tasks.MailAddressResolver;
 import hudson.util.Secret;
@@ -14,11 +15,17 @@ import org.jvnet.hudson.test.JenkinsRule;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import org.junit.BeforeClass;
 
 /**
  * Tests the plugin when logging in to rroemhild/test-openldap
  */
 public class PlanetExpressTest {
+
+    @BeforeClass public static void linuxOnly() {
+        assumeFalse("Windows CI builders now have Docker installed…but it does not support Linux images", Functions.isWindows());
+    }
 
     @Rule
     public DockerRule<PlanetExpress> docker = new DockerRule<>(PlanetExpress.class);

--- a/src/test/java/hudson/security/docker/PlanetExpressTest.java
+++ b/src/test/java/hudson/security/docker/PlanetExpressTest.java
@@ -24,7 +24,7 @@ import org.junit.BeforeClass;
 public class PlanetExpressTest {
 
     @BeforeClass public static void linuxOnly() {
-        assumeFalse("Windows CI builders now have Docker installed…but it does not support Linux images", Functions.isWindows());
+        assumeFalse("Windows CI builders now have Docker installed…but it does not support Linux images", Functions.isWindows() && System.getenv("JENKINS_URL") != null);
     }
 
     @Rule


### PR DESCRIPTION
These started failing regularly recently.

BTW the Dockerized tests are _flaky_ on Linux too: CI shows several recent failures like

```
starting slapd on port 389 and 636...
5ea00f09 @(#) $OpenLDAP: slapd  (Aug 10 2019 19:17:00) $
	Debian OpenLDAP Maintainers <pkg-openldap-devel@lists.alioth.debian.org>
5ea00f0a ch_calloc of 1048576 elems of 704 bytes failed
slapd: ../../../../servers/slapd/ch_malloc.c:107: ch_calloc: Assertion `0' failed.
```