### PR TITLE
Remove traces of tabular markup from LDAP forms

### DIFF
--- a/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
+++ b/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
@@ -27,14 +27,12 @@ THE SOFTWARE.
          xmlns:v="/jenkins/security/plugins/ldap/validation">
     <f:entry>
         <f:repeatable field="configurations" minimum="1" header="${%Server}" add="${%Add Server}">
-            <table style="width:100%">
-                <st:include page="config.jelly" class="jenkins.security.plugins.ldap.LDAPConfiguration"/>
-                <f:entry title="">
-                    <div align="right">
-                        <f:repeatableDeleteButton/>
-                    </div>
-                </f:entry>
-            </table>
+            <st:include page="config.jelly" class="jenkins.security.plugins.ldap.LDAPConfiguration"/>
+            <f:entry title="">
+                <div align="right">
+                    <f:repeatableDeleteButton/>
+                </div>
+            </f:entry>
         </f:repeatable>
     </f:entry>
     <j:choose>

--- a/src/main/resources/jenkins/security/plugins/ldap/validation/validate.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/validation/validate.jelly
@@ -65,12 +65,12 @@
            <h2>${dialog}</h2>
         </div>
         <div class="bd">
-        <table id="${uid}_dialog" width="100%">
+        <div id="${uid}_dialog">
           <d:invokeBody/>
           <f:entry>
             <input type="submit" name="Validate" value="${attrs.submit}" class="ldap-validate submit-button primary" onclick="return false;"/>
           </f:entry>
-        </table>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Follow up on [JENKINS-62809](https://issues.jenkins.io/browse/JENKINS-62809)

This PR removes all traces of tabular markup from the plugin.  The minimum jenkins version is 2.266 so no need to keep backwards compatibility.

