### PR TITLE
Use digest to get base ldap docker image

### DIFF
--- a/src/test/resources/hudson/security/docker/PlanetExpressTest/PlanetExpress/Dockerfile
+++ b/src/test/resources/hudson/security/docker/PlanetExpressTest/PlanetExpress/Dockerfile
@@ -1,1 +1,1 @@
-FROM rroemhild/test-openldap:latest
+FROM rroemhild/test-openldap@sha256:b4e433bbcba1f17899d6bcb0a8e854bbe52c754faa4e785d0c27a2b55eb12cd8


### PR DESCRIPTION
The docker image used to have a LDAP server for the tests was changed recently. And using `latest` couldn't warn us of that. However, using the digest, we will at least know when this image is not available anymore.

This is required for PCT run.