### PR TITLE
Add the choice of whether to perform certificate verification when connect to ldaps://

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -251,6 +251,14 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
     public transient String server;
 
     /**
+     * whether to verify ldaps sever certificate? default is false
+     */
+    @SuppressFBWarnings(value = "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD",
+            justification = "This public field is exposed to the plugin's API")
+    @Deprecated @Restricted(NoExternalUse.class)
+    public transient boolean sslVerify;
+
+    /**
      * The root DN to connect to. Normally something like "dc=sun,dc=com"
      *
      * How do I infer this?
@@ -415,17 +423,17 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, managerDN, managerPassword, inhibitInferRootDN, false);
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN) {
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, managerDN, managerPassword, inhibitInferRootDN, false);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN,
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN,
                              boolean disableMailAddressResolver) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, managerDN, managerPassword, inhibitInferRootDN,
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, managerDN, managerPassword, inhibitInferRootDN,
                                      disableMailAddressResolver, null);
     }
 
@@ -433,57 +441,57 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN,
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String managerDN, String managerPassword, boolean inhibitInferRootDN,
                              boolean disableMailAddressResolver, CacheConfiguration cache) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, null, null, managerDN, managerPassword, inhibitInferRootDN, disableMailAddressResolver, cache);
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, null, null, managerDN, managerPassword, inhibitInferRootDN, disableMailAddressResolver, cache);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, String managerPassword, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipFilter, managerDN, managerPassword, inhibitInferRootDN, disableMailAddressResolver, cache, null);
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, String managerPassword, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache) {
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipFilter, managerDN, managerPassword, inhibitInferRootDN, disableMailAddressResolver, cache, null);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, String managerPassword, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipFilter, managerDN, managerPassword, inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, null, null);
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, String managerPassword, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties) {
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipFilter, managerDN, managerPassword, inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, null, null);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, String managerPassword, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipFilter, managerDN, Secret.fromString(managerPassword), inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, null, null);
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, String managerPassword, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipFilter, managerDN, Secret.fromString(managerPassword), inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, null, null);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, new FromGroupSearchLDAPGroupMembershipStrategy(groupMembershipFilter), managerDN, managerPasswordSecret, inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, displayNameAttributeName, mailAddressAttributeName);
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, String groupMembershipFilter, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, new FromGroupSearchLDAPGroupMembershipStrategy(groupMembershipFilter), managerDN, managerPasswordSecret, inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, displayNameAttributeName, mailAddressAttributeName);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
-        this(server, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipStrategy, managerDN, managerPasswordSecret, inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, displayNameAttributeName, mailAddressAttributeName, IdStrategy.CASE_INSENSITIVE, IdStrategy.CASE_INSENSITIVE);
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+        this(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipStrategy, managerDN, managerPasswordSecret, inhibitInferRootDN, disableMailAddressResolver, cache, environmentProperties, displayNameAttributeName, mailAddressAttributeName, IdStrategy.CASE_INSENSITIVE, IdStrategy.CASE_INSENSITIVE);
     }
 
     /**
      * @deprecated retained for backwards binary compatibility.
      */
     @Deprecated
-    public LDAPSecurityRealm(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName, IdStrategy userIdStrategy, IdStrategy groupIdStrategy) {
-        this(createLdapConfiguration(server, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipStrategy, managerDN, managerPasswordSecret, inhibitInferRootDN, environmentProperties, displayNameAttributeName, mailAddressAttributeName),
+    public LDAPSecurityRealm(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, boolean disableMailAddressResolver, CacheConfiguration cache, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName, IdStrategy userIdStrategy, IdStrategy groupIdStrategy) {
+        this(createLdapConfiguration(server, sslVerify, rootDN, userSearchBase, userSearch, groupSearchBase, groupSearchFilter, groupMembershipStrategy, managerDN, managerPasswordSecret, inhibitInferRootDN, environmentProperties, displayNameAttributeName, mailAddressAttributeName),
                 disableMailAddressResolver, cache, userIdStrategy, groupIdStrategy);
     }
 
@@ -514,8 +522,8 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
         this.groupIdStrategy = groupIdStrategy;
     }
 
-    private static List<LDAPConfiguration> createLdapConfiguration(String server, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
-        LDAPConfiguration conf = new LDAPConfiguration(server, rootDN, inhibitInferRootDN, managerDN, managerPasswordSecret);
+    private static List<LDAPConfiguration> createLdapConfiguration(String server, boolean sslVerify, String rootDN, String userSearchBase, String userSearch, String groupSearchBase, String groupSearchFilter, LDAPGroupMembershipStrategy groupMembershipStrategy, String managerDN, Secret managerPasswordSecret, boolean inhibitInferRootDN, EnvironmentProperty[] environmentProperties, String displayNameAttributeName, String mailAddressAttributeName) {
+        LDAPConfiguration conf = new LDAPConfiguration(server, sslVerify, rootDN, inhibitInferRootDN, managerDN, managerPasswordSecret);
         conf.setUserSearchBase(userSearchBase);
         conf.setUserSearch(userSearch);
         conf.setGroupSearchBase(groupSearchBase);
@@ -550,7 +558,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             managerPassword = null;
         }
         if (server != null) {
-            LDAPConfiguration conf = new LDAPConfiguration(server, rootDN, inhibitInferRootDN, managerDN, managerPasswordSecret);
+            LDAPConfiguration conf = new LDAPConfiguration(server, sslVerify, rootDN, inhibitInferRootDN, managerDN, managerPasswordSecret);
             server = null;
             rootDN = null;
             managerDN = null;
@@ -1587,7 +1595,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             // we can only do deep validation if the connection is correct
             LDAPConfiguration.LDAPConfigurationDescriptor confDescriptor = Jenkins.getActiveInstance().getDescriptorByType(LDAPConfiguration.LDAPConfigurationDescriptor.class);
             for (LDAPConfiguration configuration : realm.getConfigurations()) {
-                FormValidation connectionCheck = confDescriptor.doCheckServer(configuration.getServerUrl(), configuration.getManagerDN(), configuration.getManagerPasswordSecret());
+                FormValidation connectionCheck = confDescriptor.doCheckServer(configuration.getServerUrl(), configuration.isSslVerify(), configuration.getManagerDN(), configuration.getManagerPasswordSecret());
                 if (connectionCheck.kind != FormValidation.Kind.OK) {
                     return connectionCheck;
                 }

--- a/src/main/java/jenkins/security/plugins/ldap/BlindSSLSocketFactory.java
+++ b/src/main/java/jenkins/security/plugins/ldap/BlindSSLSocketFactory.java
@@ -1,0 +1,96 @@
+package jenkins.security.plugins.ldap;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+public class BlindSSLSocketFactory extends SSLSocketFactory {
+    private static final BlindSSLSocketFactory INSTANCE;
+
+    static {
+        final X509TrustManager dummyTrustManager =
+                new X509TrustManager() {
+                    @Override
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+
+                    @Override
+                    public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+                    @Override
+                    public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+                };
+        try {
+            final SSLContext context = SSLContext.getInstance("SSL");
+            final TrustManager[] trustManagers = {dummyTrustManager};
+            final SecureRandom rng = new SecureRandom();
+            context.init(null, trustManagers, rng);
+            INSTANCE = new BlindSSLSocketFactory(context.getSocketFactory());
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException("Cannot create BlindSslSocketFactory", e);
+        }
+    }
+
+    public static SocketFactory getDefault() {
+        return INSTANCE;
+    }
+
+    private final SSLSocketFactory sslFactory;
+
+    private BlindSSLSocketFactory(SSLSocketFactory sslFactory) {
+        this.sslFactory = sslFactory;
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose)
+            throws IOException {
+        return sslFactory.createSocket(s, host, port, autoClose);
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return sslFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return sslFactory.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return sslFactory.createSocket();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return sslFactory.createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return sslFactory.createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+            throws IOException, UnknownHostException {
+        return sslFactory.createSocket(host, port, localHost, localPort);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+            throws IOException {
+        return sslFactory.createSocket(address, port, localAddress, localPort);
+    }
+}

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/config.jelly
@@ -4,6 +4,9 @@
         <f:textbox/>
     </f:entry>
     <f:advanced title="${%Advanced Server Configuration}">
+        <f:entry field="sslVerify">
+            <f:checkbox title="${%SSL Verify}"/>
+        </f:entry>
         <f:entry field="rootDN" title="${%root DN}">
             <f:textbox/>
         </f:entry>

--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-sslVerify.html
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-sslVerify.html
@@ -1,0 +1,9 @@
+<div>
+    <p>
+        If checked and ldap server is an ldaps:// style URL, requiring the certificate to be verified.
+    </p>
+    <p>
+        If unchecked (the default), Jenkins will not verify the server certificate when it connects to
+        perform a query.
+    </p>
+</div>


### PR DESCRIPTION
When connecting to LDAP server over SSL/TLS(LDAPS) with self-signed certificate, the jenkins server cannot connect to LDAP server.  
The error log shows that [Root exception is javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target].

If we can get the cert from LDAP server, we import the cert to trust cacerts in jenkins server. Then the above error can be resolved. But if there are multiple servers, this is a bit troublesome. 

Another way is to skip certificate validation.

Add the choice "SSL Verify" in LDAP configuarion for users to choose:
1. If checked and ldap server is an ldaps:// style URL, requiring the certificate to be verified.
2. If unchecked (the default), Jenkins will not verify the server certificate.

