### PR TITLE
Include RootDN in doCheckServer

### DIFF
--- a/src/main/java/hudson/security/LDAPSecurityRealm.java
+++ b/src/main/java/hudson/security/LDAPSecurityRealm.java
@@ -1587,7 +1587,7 @@ public class LDAPSecurityRealm extends AbstractPasswordBasedSecurityRealm {
             // we can only do deep validation if the connection is correct
             LDAPConfiguration.LDAPConfigurationDescriptor confDescriptor = Jenkins.getActiveInstance().getDescriptorByType(LDAPConfiguration.LDAPConfigurationDescriptor.class);
             for (LDAPConfiguration configuration : realm.getConfigurations()) {
-                FormValidation connectionCheck = confDescriptor.doCheckServer(configuration.getServerUrl(), configuration.getManagerDN(), configuration.getManagerPasswordSecret());
+                FormValidation connectionCheck = confDescriptor.doCheckServer(configuration.getServerUrl(), configuration.getManagerDN(), configuration.getManagerPasswordSecret(),configuration.getRootDN());
                 if (connectionCheck.kind != FormValidation.Kind.OK) {
                     return connectionCheck;
                 }

--- a/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
@@ -396,7 +396,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
             return "ldap";
         }
 
-        public FormValidation doCheckServer(@QueryParameter String value, @QueryParameter String managerDN, @QueryParameter Secret managerPasswordSecret) {
+        public FormValidation doCheckServer(@QueryParameter String value, @QueryParameter String managerDN, @QueryParameter Secret managerPasswordSecret,@QueryParameter String rootDN) {
             String server = value;
             String managerPassword = Secret.toString(managerPasswordSecret);
 
@@ -412,7 +412,7 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
                     props.put(Context.SECURITY_CREDENTIALS,managerPassword);
                 }
                 props.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-                props.put(Context.PROVIDER_URL, LDAPSecurityRealm.toProviderUrl(server, ""));
+                props.put(Context.PROVIDER_URL, LDAPSecurityRealm.toProviderUrl(server,rootDN));
 
                 DirContext ctx = new InitialDirContext(props);
                 ctx.getAttributes("");


### PR DESCRIPTION
Includes the rootDN in the initial request to the server to check for availability.

This fixes a problem I've had while trying to setup [Google LDAP](https://support.google.com/a/answer/9048516?hl=en) for the Jenkins instance I manage.

The initial request does not include the rootDN when connecting to `ldap.google.com`, which returns a 
`INSUFFICIENT_ACCESS_RIGHTS (50)` upon doing so. 
Including the DN directly in the URL of the LDAP server (like `ldaps://ldap.google.com/dc=example,dc=org`) also does not work, as its interpreted as an URL - therefore the requests turn into `dc=example,dc=org/`, which makes the user check fail at a later point.
