### PR TITLE
Do not connect to `ldap.itd.umich.edu` in tests

### DIFF
--- a/src/test/java/hudson/security/LDAPSecurityRealmTest.java
+++ b/src/test/java/hudson/security/LDAPSecurityRealmTest.java
@@ -132,7 +132,7 @@ public class LDAPSecurityRealmTest {
         final String previousValue = "previousValue";
         final String testValue = "testValue";
         final LDAPSecurityRealm realm = new LDAPSecurityRealm(
-                "ldap.itd.umich.edu",
+                "localhost",
                 null,
                 null,
                 null,
@@ -178,7 +178,7 @@ public class LDAPSecurityRealmTest {
 
     @Test
     public void configRoundTrip() throws Exception {
-        final String server = "ldap.itd.umich.edu";
+        final String server = "localhost";
         final String rootDN = "ou=umich,dc=ou.edu";
         final String userSearchBase = "cn=users,ou=umich,ou.edu";
         final String managerDN = "cn=admin,ou=umich,ou.edu";
@@ -367,7 +367,7 @@ public class LDAPSecurityRealmTest {
 
     @Test
     public void configRoundTripEnvironmentProperties() throws Exception {
-        final String server = "ldap.itd.umich.edu";
+        final String server = "localhost";
         final String rootDN = "ou=umich,dc=ou.edu";
         final String userSearchBase = "cn=users,ou=umich,ou.edu";
         final String managerDN = "cn=admin,ou=umich,ou.edu";


### PR DESCRIPTION
https://github.com/jenkinsci/bom/pull/883#issuecomment-1041489253

Cannot reproduce test failure locally with Internet disabled, but do see warnings which would suggest that the test could actually hang under some network conditions:

<details>

```
WARNING	j.s.p.ldap.LDAPConfiguration#inferRootDN: Failed to connect to LDAP to infer Root DN for ldap.itd.umich.edu
java.net.UnknownHostException: ldap.itd.umich.edu
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:184)
	at …
	at com.sun.jndi.ldap.Connection.createSocket(Connection.java:380)
	at com.sun.jndi.ldap.Connection.<init>(Connection.java:220)
Caused: javax.naming.CommunicationException: ldap.itd.umich.edu:389 [Root exception is java.net.UnknownHostException: ldap.itd.umich.edu]
	at com.sun.jndi.ldap.Connection.<init>(Connection.java:243)
	at com.sun.jndi.ldap.LdapClient.<init>(LdapClient.java:137)
	at com.sun.jndi.ldap.LdapClient.getInstance(LdapClient.java:1615)
	at com.sun.jndi.ldap.LdapCtx.connect(LdapCtx.java:2849)
	at com.sun.jndi.ldap.LdapCtx.<init>(LdapCtx.java:347)
	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxFromUrl(LdapCtxFactory.java:225)
	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURL(LdapCtxFactory.java:189)
	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURLs(LdapCtxFactory.java:243)
	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(LdapCtxFactory.java:154)
	at com.sun.jndi.ldap.LdapCtxFactory.getInitialContext(LdapCtxFactory.java:84)
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:695)
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:313)
	at javax.naming.InitialContext.init(InitialContext.java:244)
	at javax.naming.InitialContext.<init>(InitialContext.java:216)
	at javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:101)
	at jenkins.security.plugins.ldap.LDAPConfiguration.inferRootDN(LDAPConfiguration.java:494)
	at jenkins.security.plugins.ldap.LDAPConfiguration.<init>(LDAPConfiguration.java:157)
	at hudson.security.LDAPSecurityRealm.createLdapConfiguration(LDAPSecurityRealm.java:518)
	at hudson.security.LDAPSecurityRealm.<init>(LDAPSecurityRealm.java:486)
	at hudson.security.LDAPSecurityRealmTest.groupMembershipAttribute(LDAPSecurityRealmTest.java:134)
	at …
WARNING	j.s.p.ldap.LDAPConfiguration#inferRootDN: Failed to connect to LDAP to infer Root DN for ldap.itd.umich.edu
java.net.UnknownHostException: ldap.itd.umich.edu
	at …
Caused: javax.naming.CommunicationException: ldap.itd.umich.edu:389 [Root exception is java.net.UnknownHostException: ldap.itd.umich.edu]
	at com.sun.jndi.ldap.Connection.<init>(Connection.java:243)
	at com.sun.jndi.ldap.LdapClient.<init>(LdapClient.java:137)
	at com.sun.jndi.ldap.LdapClient.getInstance(LdapClient.java:1615)
	at com.sun.jndi.ldap.LdapCtx.connect(LdapCtx.java:2849)
	at com.sun.jndi.ldap.LdapCtx.<init>(LdapCtx.java:347)
	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxFromUrl(LdapCtxFactory.java:225)
	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURL(LdapCtxFactory.java:189)
	at com.sun.jndi.ldap.LdapCtxFactory.getUsingURLs(LdapCtxFactory.java:243)
	at com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(LdapCtxFactory.java:154)
	at com.sun.jndi.ldap.LdapCtxFactory.getInitialContext(LdapCtxFactory.java:84)
	at javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:695)
	at javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:313)
	at javax.naming.InitialContext.init(InitialContext.java:244)
	at javax.naming.InitialContext.<init>(InitialContext.java:216)
	at javax.naming.directory.InitialDirContext.<init>(InitialDirContext.java:101)
	at jenkins.security.plugins.ldap.LDAPConfiguration.inferRootDN(LDAPConfiguration.java:494)
	at jenkins.security.plugins.ldap.LDAPConfiguration.<init>(LDAPConfiguration.java:157)
	at …
	at org.kohsuke.stapler.RequestImpl.invokeConstructor(RequestImpl.java:530)
	at …
	at hudson.model.Descriptor.newInstance(Descriptor.java:598)
	at hudson.security.LDAPSecurityRealm$DescriptorImpl.newInstance(LDAPSecurityRealm.java:1508)
	at hudson.security.LDAPSecurityRealm$DescriptorImpl.newInstance(LDAPSecurityRealm.java:1465)
	at hudson.DescriptorExtensionList.newInstanceFromRadioList(DescriptorExtensionList.java:149)
	at hudson.DescriptorExtensionList.newInstanceFromRadioList(DescriptorExtensionList.java:163)
	at hudson.security.GlobalSecurityConfiguration.configure(GlobalSecurityConfiguration.java:123)
	at hudson.security.GlobalSecurityConfiguration.doConfigure(GlobalSecurityConfiguration.java:108)
	at …
```

</details>
