### PR TITLE
End the bold tag in groupSearchBase help file

### DIFF
--- a/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-groupSearchBase.html
+++ b/src/main/resources/jenkins/security/plugins/ldap/LDAPConfiguration/help-groupSearchBase.html
@@ -8,7 +8,7 @@
     If login attempts result in "Administrative Limit Exceeded" or similar error, try to
     make this setting as specific as possible for your LDAP structure, to reduce the scope
     of the query. If the error persists, you may need to edit the
-    <b>Group search filter<b>. Change: <br/>
+    <b>Group search filter</b>. Change: <br/>
     <tt>groupSearchFilter = "(| (member={0}) (uniqueMember={0}) (memberUid={1}))";</tt><br/>
     to query only of the field used in your LDAP for group membership, such as: <br/>
     <tt>groupSearchFilter = "(member={0})";</tt><br/>


### PR DESCRIPTION
## End the bold tag in the groupSearchBase help file

The dangling bold tag in the groupSearchBase help file causes the configuration as code reference help to be bold text for about 50% of the page in my Jenkins installation.  End the bold tag on the same line that it was started so that other reference files that include it are not stuck with bold enabled.

I can submit a Jira issue if needed.  This seemed simple enough to not be worth the effort of a Jira issue.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
