### PR TITLE
[JENKINS-68462] Prepare LDAP for removal of JAXB and Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <apacheds.version>2.0.0.AM25</apacheds.version>
-    <jenkins.version>2.289.3</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
   </properties>
 
   <scm>
@@ -297,7 +297,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
+        <artifactId>bom-2.332.x</artifactId>
         <version>1289.v5c4b_1c43511b_</version>
         <scope>import</scope>
         <type>pom</type>


### PR DESCRIPTION
See [JENKINS-68462](https://issues.jenkins.io/browse/JENKINS-68462). The current version of this plugin bundles an old version of `spring-ldap-core`, which requires JAXB. When we start requiring Java 11, JAXB will not be available except as a plugin-to-plugin dependency (which this plugin does not have). In https://github.com/spring-projects/spring-ldap/issues/590 `spring-ldap-core` 2.3.5 and later stopped requiring JAXB. This PR updates the core baseline to 2.332.x, which pulls in a newer version of `spring-security-bom`, which pulls in `spring-ldap-core` 2.3.5 (2.303.x pulls in 2.3.4, sadly). Thus with this update we start shipping `spring-ldap-core` 2.3.5 which no longer depends on JAXB, and thus we are assured of a smooth upgrade for users when we start requiring Java 11.

### Testing done

```
$ mvn clean verify
[…]
[INFO] Assembling webapp ldap in ldap-plugin/target/ldap
[INFO] Bundling direct dependency time4j-base-5.8.jar
[INFO] Bundling direct dependency time4j-tzdata-5.0-2021e.jar
[WARNING] Bundling transitive dependency spring-ldap-core-2.3.5.RELEASE.jar (via spring-security-ldap)
[INFO] Bundling direct dependency spring-security-ldap-5.6.1.jar
[WARNING] Bundling transitive dependency spring-tx-5.3.14.jar (via spring-security-ldap)
[INFO] Generating hpi ldap-plugin/target/ldap.hpi
[INFO] Building jar: ldap-plugin/target/ldap.hpi
[…]
$
```