### PR TITLE
Bump parent pom and bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.55</version>
+    <version>4.60</version>
     <relativePath/>
   </parent>
 
@@ -297,7 +297,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.361.x</artifactId>
-        <version>1841.v7b_22c5218e1a</version>
+        <version>2000.v4677a_6e0ffea</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
it's required for https://github.com/jenkinsci/jenkins/pull/7781 so that tests continue passing in this plugin and in bom, currently failing in https://github.com/jenkinsci/bom/pull/1968.

Can this be released please?