### PR TITLE
Replace Prototype.js with native JavaScript

### DIFF
--- a/src/main/resources/jenkins/security/plugins/ldap/validation/validate/validate.js
+++ b/src/main/resources/jenkins/security/plugins/ldap/validation/validate/validate.js
@@ -77,24 +77,26 @@ function ldapValidateButton(checkUrl, formFilter, button, id) {
                 for (var i = 0; i < inputs.length; i++) {
                     json[inputs[i].name] = inputs[i].value;
                 }
-                new Ajax.Request(checkUrl, {
-                    contentType: "application/json",
-                    encoding: "UTF-8",
-                    method: 'post',
-                    requestHeaders: {'Crumb': crumb},
-                    postBody: Object.toJSON(json),
-                    onComplete: function (rsp) {
+                // TODO simplify when Prototype.js is removed
+                fetch(checkUrl, {
+                    method: "post",
+                    headers: crumb.wrap({
+                        "Content-Type": "application/json",
+                    }),
+                    body: Object.toJSON ? Object.toJSON(json) : JSON.stringify(json),
+                }).then(function(rsp) {
+                    rsp.text().then((responseText) => {
                         spinner.style.display = "none";
                         target.innerHTML = `<div class="validation-error-area" />`;
-                        updateValidationArea(target, rsp.responseText);
+                        updateValidationArea(target, responseText);
                         layoutUpdateCallback.call();
-                        var s = rsp.getResponseHeader("script");
+                        var s = rsp.headers.get("script");
                         try {
                             geval(s);
                         } catch (e) {
                             window.alert("failed to evaluate " + s + "\n" + e.message);
                         }
-                    }
+                    });
                 });
                 cleanUp();
             };


### PR DESCRIPTION
See [JENKINS-70906](https://issues.jenkins.io/browse/JENKINS-70906). Jenkins core currently uses [Prototype 1.7](https://github.com/prototypejs/prototype/releases/tag/1.7), released on November 15, 2010. The latest version is [Prototype 1.7.3](https://github.com/prototypejs/prototype/releases/tag/1.7.3), released on September 22, 2015. When an attempt was made to upgrade to 1.7.3 in 2018 in [JENKINS-49319](https://issues.jenkins.io/browse/JENKINS-49319), the change had to be reverted. Since this library has been unmaintained for the past 8 years, this PR removes any usages of it in favor of native JavaScript APIs. To test this, I installed this plugin on a custom build of Jenkins that had Prototype ripped out (a local project branch), went to the Security page and tried to validate a dummy LDAP configuration. I verified that the changed lines were executed correctly.