### PR TITLE
Use new dialog design for validation dialog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <apacheds.version>2.0.0.AM25</apacheds.version>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.426.3</jenkins.version>
   </properties>
 
   <scm>
@@ -296,8 +296,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.426.x</artifactId>
+        <version>2839.v003b_4d9d24fd</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/resources/jenkins/security/plugins/ldap/validation/validate.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/validation/validate.jelly
@@ -53,19 +53,17 @@
     <j:set var="uid" value="${h.generateId()}" />
     <div style="float:right" class="ldap-validate-section">
       <span class="ldap-validate-button-reference-holder" data-id="${uid}"
-      data-fullurl="${descriptor.descriptorFullUrl}/${method}"
-      data-attributes="${attrs.filter}"
-      data-dialogTitle="${dialog}"
-      data-submit="${attrs.submit}"/>
+        data-fullurl="${descriptor.descriptorFullUrl}/${method}"
+        data-attributes="${attrs.filter}"
+        data-dialogTitle="${dialog}"
+        data-submit="${attrs.submit}"/>
       <button id="${uid}" type="button" name="${name}" class="ldap-validate-button jenkins-button">
         ${title}
       </button>
       <st:adjunct includes="jenkins.security.plugins.ldap.validation.validateButton"/>
       <div id="${uid}_div" style="display:none;" class="ldap-validate-form">
-        <div class="bd">
         <div id="${uid}_dialog">
           <d:invokeBody/>
-        </div>
         </div>
       </div>
     </div>

--- a/src/main/resources/jenkins/security/plugins/ldap/validation/validate.jelly
+++ b/src/main/resources/jenkins/security/plugins/ldap/validation/validate.jelly
@@ -52,27 +52,19 @@
   <f:entry>
     <j:set var="uid" value="${h.generateId()}" />
     <div style="float:right" class="ldap-validate-section">
-      <span class="yui-button">
-        <span>
-        <span class="ldap-validate-button-reference-holder" data-id="${uid}" data-fullurl="${descriptor.descriptorFullUrl}/${method}" data-attributes="${attrs.filter}"/>
-          <button id="${uid}" type="button" name="${name}" class="ldap-validate-button">
-            ${title}
-          </button>
-          <st:adjunct includes="jenkins.security.plugins.ldap.validation.validateButton"/>
-        </span>
-      </span>
+      <span class="ldap-validate-button-reference-holder" data-id="${uid}"
+      data-fullurl="${descriptor.descriptorFullUrl}/${method}"
+      data-attributes="${attrs.filter}"
+      data-dialogTitle="${dialog}"
+      data-submit="${attrs.submit}"/>
+      <button id="${uid}" type="button" name="${name}" class="ldap-validate-button jenkins-button">
+        ${title}
+      </button>
+      <st:adjunct includes="jenkins.security.plugins.ldap.validation.validateButton"/>
       <div id="${uid}_div" style="display:none;" class="ldap-validate-form">
-        <div class="hd">
-           <h2>${dialog}</h2>
-        </div>
         <div class="bd">
         <div id="${uid}_dialog">
           <d:invokeBody/>
-          <f:entry>
-        <span class="ldap-validate-input-button-reference-holder"/>
-            <input id="ldap-validate-input" type="submit" name="Validate" value="${attrs.submit}" class="ldap-validate submit-button primary"/>
-            <st:adjunct includes="jenkins.security.plugins.ldap.validation.validateButtonOnClick"/>
-          </f:entry>
         </div>
         </div>
       </div>

--- a/src/main/resources/jenkins/security/plugins/ldap/validation/validateButton.js
+++ b/src/main/resources/jenkins/security/plugins/ldap/validation/validateButton.js
@@ -1,11 +1,8 @@
 
  Behaviour.specify(".ldap-validate-button-reference-holder", 'ldap-validate', 0, function (e) {
-     var url = e.getAttribute('data-fullurl');
-     var attr = e.getAttribute('data-attributes')
-     var id = e.getAttribute('data-id');
-     var button = document.getElementById(id);
+     const button = document.getElementById(e.dataset['id']);
      button.onclick = function(el) {
-        ldapValidateButton(url,attr,this,id);
+        ldapValidateButton(this, e.dataset);
         return false;
      }
  });

--- a/src/main/resources/jenkins/security/plugins/ldap/validation/validateButtonOnClick.js
+++ b/src/main/resources/jenkins/security/plugins/ldap/validation/validateButtonOnClick.js
@@ -1,7 +1,0 @@
-
-Behaviour.specify(".ldap-validate-input-button-reference-holder", 'ldap-validate', 0, function (e) {
-    var validateinp = document.getElementById("ldap-validate-input");
-    validateinp.onclick = function(el) {
-       return false;
-    }
-});

--- a/src/test/java/hudson/security/LDAPEmbeddedTest.java
+++ b/src/test/java/hudson/security/LDAPEmbeddedTest.java
@@ -25,7 +25,6 @@
 package hudson.security;
 
 import org.htmlunit.FailingHttpStatusCodeException;
-import org.htmlunit.html.DomElement;
 import org.htmlunit.html.HtmlButton;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlInput;
@@ -666,14 +665,7 @@ public class LDAPEmbeddedTest {
             final HtmlInput testPassword = security.getElementByName("testPassword");
             testPassword.setValue("pass");
 
-            HtmlButton submitElement = null;
-            for (DomElement e : security.getElementsByTagName("button")) {
-                if ("submit".equals(e.getAttribute("type")) && "Test".equals(e.getTextContent())) {
-                    submitElement = (HtmlButton) e;
-                    break;
-                }
-            }
-
+            HtmlButton submitElement = security.querySelector("button[data-id=\"ok\"]");
             assertThat(submitElement, notNullValue());
             submitElement.click();
 


### PR DESCRIPTION
Updated the dialog design to remove dependency on YUI and improve theme support (https://github.com/jenkinsci/dark-theme-plugin/issues/142 ). Analogous to https://github.com/jenkinsci/credentials-plugin/pull/500

<details>
<summary>Screenshot</summary>

![image](https://github.com/jenkinsci/ldap-plugin/assets/1105305/29808445-242e-435c-be64-6222584b08e0)

</details>

### Testing done

Checked that dialog displays OK and Test button validates the data. I don't have a proper LDAP server running so I wasn't able to get successful validation, just checked that the data being validated looks OK.
```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
