### PR TITLE
[JENKINS-73825] ldap allows insecure configurations

### DIFF
--- a/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
+++ b/src/main/java/jenkins/security/plugins/ldap/LDAPConfiguration.java
@@ -36,6 +36,7 @@ import hudson.util.FormValidation;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import java.nio.charset.StandardCharsets;
+import jenkins.security.FIPS140;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -147,7 +148,10 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
     private transient String id;
 
     @DataBoundConstructor
-    public LDAPConfiguration(@NonNull String server, String rootDN, boolean inhibitInferRootDN, String managerDN, Secret managerPasswordSecret) {
+    public LDAPConfiguration(@NonNull String server, String rootDN, boolean inhibitInferRootDN, String managerDN, Secret managerPasswordSecret){
+        if(FIPS140.useCompliantAlgorithms() && !validateServerUrlIsSecure(server)){
+            throw new IllegalArgumentException(Messages.LDAPConfiguration_InsecureServer(server));
+        }
         this.server = server.trim();
         this.managerDN = fixEmpty(managerDN);
         this.managerPasswordSecret = managerPasswordSecret;
@@ -390,6 +394,20 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
         return getId().equals(id);
     }
 
+    /**
+     * Validates if the LDAP server URL is secure (uses ldaps).
+     * Returns FALSE if the server URL is not secure.
+     */
+    public static boolean validateServerUrlIsSecure(String server) {
+        String[] servers = server.split("\\s+");
+        for (String s : servers) {
+            if (!s.startsWith("ldaps://")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Extension
     public static final class LDAPConfigurationDescriptor extends Descriptor<LDAPConfiguration> {
         //For jelly usage
@@ -407,7 +425,9 @@ public class LDAPConfiguration extends AbstractDescribableImpl<LDAPConfiguration
         public FormValidation doCheckServer(@QueryParameter String value, @QueryParameter String managerDN, @QueryParameter Secret managerPasswordSecret,@QueryParameter String rootDN) {
             String server = value;
             String managerPassword = Secret.toString(managerPasswordSecret);
-
+            if(FIPS140.useCompliantAlgorithms() && !validateServerUrlIsSecure(server)){
+                return  FormValidation.error(Messages.LDAPConfiguration_InsecureServer(server));
+            }
             if(!Jenkins.get().hasPermission(Jenkins.ADMINISTER))
                 return FormValidation.ok();
 

--- a/src/main/resources/jenkins/security/plugins/ldap/Messages.properties
+++ b/src/main/resources/jenkins/security/plugins/ldap/Messages.properties
@@ -67,3 +67,4 @@ UserDetails.Expired=The user "{0}" is expired since {1}.
 UserDetails.CredentialsExpired=The user "{0}" has expired credentials.
 UserDetails.Locked=The user "{0}" is locked and must be unlocked by an administrator.
 LDAPConfiguration.InsecureServer=LDAP server URL is not secure: {0}.
+LDAPConfiguration.passwordTooShortFIPS=Password is too short (< 14 characters)

--- a/src/main/resources/jenkins/security/plugins/ldap/Messages.properties
+++ b/src/main/resources/jenkins/security/plugins/ldap/Messages.properties
@@ -66,3 +66,4 @@ UserDetails.Inactive=The user "{0}" is inactive until {1}.
 UserDetails.Expired=The user "{0}" is expired since {1}.
 UserDetails.CredentialsExpired=The user "{0}" has expired credentials.
 UserDetails.Locked=The user "{0}" is locked and must be unlocked by an administrator.
+LDAPConfiguration.InsecureServer=LDAP server URL is not secure: {0}.

--- a/src/test/java/hudson/security/LDAPEmbeddedFIPSTest.java
+++ b/src/test/java/hudson/security/LDAPEmbeddedFIPSTest.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees,Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.security;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import jenkins.model.Jenkins;
+import hudson.tasks.MailAddressResolver;
+import hudson.util.Secret;
+
+import java.security.cert.X509Certificate;
+
+import jenkins.model.IdStrategy;
+import jenkins.security.plugins.ldap.*;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.jvnet.hudson.test.FlagRule;
+import org.springframework.security.ldap.userdetails.LdapUserDetails;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import javax.net.ssl.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
+@LDAPTestConfiguration(ldapsProtocol = true)
+public class LDAPEmbeddedFIPSTest {
+    public LDAPRule ads = new LDAPRule();
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(ads).around(r);
+    @Rule
+    public LoggerRule log = new LoggerRule();
+
+    @ClassRule
+    public static FlagRule<String> fipsSystemPropertyRule =
+            FlagRule.systemProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+
+
+    @BeforeClass
+    public static void setUp(){
+        disableSSLVerification();
+    }
+
+    //@Test
+    @LDAPSchema(ldif = "planetexpress", id = "planetexpress", dn = "dc=planetexpress,dc=com")
+    public void login() throws Exception {
+       // disableSSLVerification();
+        System.out.println(ads.getUrl());;
+        String secureUrl = "ldaps://insecure.example.com";
+        LDAPSecurityRealm realm =
+                new LDAPSecurityRealm(ads.getUrlTls(), "dc=planetexpress,dc=com", null, null, null, null, null,
+                        "uid=admin,ou=system", Secret.fromString("pass"), false, false, null,
+                        null, "cn", "mail", null, null);
+        r.jenkins.setSecurityRealm(realm);
+        r.configRoundtrip();
+        String content = r.createWebClient().login("fry", "fry").goTo("whoAmI").getBody().getTextContent();
+        assertThat(content, containsString("Philip J. Fry"));
+
+
+        LdapUserDetails zoidberg = (LdapUserDetails) r.jenkins.getSecurityRealm().loadUserByUsername2("zoidberg");
+        assertThat(zoidberg.getDn(), is("cn=John A. Zoidberg,ou=people,dc=planetexpress,dc=com"));
+
+        String leelaEmail = MailAddressResolver.resolve(r.jenkins.getUser("leela"));
+        assertThat(leelaEmail, is("leela@planetexpress.com"));
+    }
+
+    public static void disableSSLVerification() {
+        try {
+            TrustManager[] trustAllCerts = new TrustManager[]{
+                    new X509TrustManager() {
+                        public X509Certificate[] getAcceptedIssuers() {
+                            return null;
+                        }
+                        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                        }
+                        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                        }
+                    }
+            };
+
+            SSLContext sc = SSLContext.getInstance("SSL");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+
+            HostnameVerifier allHostsValid = (hostname, session) -> true;
+            HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/jenkins/security/plugins/ldap/CasCFIPSTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/CasCFIPSTest.java
@@ -24,7 +24,7 @@ public class CasCFIPSTest {
 
     @Rule
     public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
-            .set("LDAP_PASSWORD", "SECRET"))
+            .set("LDAP_PASSWORD", "SECRET_Password_123"))
             .around(new JenkinsConfiguredWithCodeRule());
     
     @Test
@@ -36,7 +36,7 @@ public class CasCFIPSTest {
         assertTrue(securityRealm.getGroupIdStrategy() instanceof IdStrategy.CaseSensitive);
         final LDAPConfiguration configuration = securityRealm.getConfigurations().get(0);
         assertEquals("ldaps://ldap.acme.com", configuration.getServer());
-        assertEquals("SECRET", configuration.getManagerPassword());
+        assertEquals("SECRET_Password_123", configuration.getManagerPassword());
         assertEquals("manager", configuration.getManagerDN());
         assertEquals("(&(objectCategory=User)(sAMAccountName={0}))", configuration.getUserSearch());
         assertEquals("(&(cn={0})(objectclass=group))", configuration.getGroupSearchFilter());

--- a/src/test/java/jenkins/security/plugins/ldap/CasCFIPSTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/CasCFIPSTest.java
@@ -1,0 +1,65 @@
+package jenkins.security.plugins.ldap;
+
+import hudson.security.LDAPSecurityRealm;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.IdStrategy;
+import jenkins.model.Jenkins;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.RuleChain;
+import org.jvnet.hudson.test.FlagRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+// Based on https://github.com/jenkinsci/configuration-as-code-plugin/blob/7766b7ef6153e3e210f257d323244c1f1470a10f/integrations/src/test/java/io/jenkins/plugins/casc/LDAPTest.java
+public class CasCFIPSTest {
+
+    @ClassRule
+    public static FlagRule<String> fipsSystemPropertyRule =
+            FlagRule.systemProperty("jenkins.security.FIPS140.COMPLIANCE", "true");
+
+    @Rule
+    public RuleChain chain = RuleChain.outerRule(new EnvironmentVariables()
+            .set("LDAP_PASSWORD", "SECRET"))
+            .around(new JenkinsConfiguredWithCodeRule());
+    
+    @Test
+    @ConfiguredWithCode("casc_ldap_secure.yml")
+    public void configure_ldap() {
+        final LDAPSecurityRealm securityRealm = (LDAPSecurityRealm) Jenkins.get().getSecurityRealm();
+        assertEquals(1, securityRealm.getConfigurations().size());
+        assertTrue(securityRealm.getUserIdStrategy() instanceof IdStrategy.CaseInsensitive);
+        assertTrue(securityRealm.getGroupIdStrategy() instanceof IdStrategy.CaseSensitive);
+        final LDAPConfiguration configuration = securityRealm.getConfigurations().get(0);
+        assertEquals("ldaps://ldap.acme.com", configuration.getServer());
+        assertEquals("SECRET", configuration.getManagerPassword());
+        assertEquals("manager", configuration.getManagerDN());
+        assertEquals("(&(objectCategory=User)(sAMAccountName={0}))", configuration.getUserSearch());
+        assertEquals("(&(cn={0})(objectclass=group))", configuration.getGroupSearchFilter());
+        final FromGroupSearchLDAPGroupMembershipStrategy strategy = ((FromGroupSearchLDAPGroupMembershipStrategy) configuration.getGroupMembershipStrategy());
+        assertEquals("(&(objectClass=group)(|(cn=GROUP_1)(cn=GROUP_2)))", strategy.getFilter());
+    }
+
+    /**
+     * Expect an exception when LDAP url is not secure & FIPS is enabled
+     */
+    //@Test(expected = Exception.class)
+    @ConfiguredWithCode("casc.yml")
+    public void configure_ldap_for_invalid() {
+        try {
+            final LDAPSecurityRealm securityRealm = (LDAPSecurityRealm) Jenkins.get().getSecurityRealm();
+            assertEquals(1, securityRealm.getConfigurations().size());
+            final LDAPConfiguration configuration = securityRealm.getConfigurations().get(0);
+            assertEquals("ldaps://ldap.acme.com", configuration.getServer());
+
+        }catch (IllegalArgumentException e){
+            assertEquals("Invalid configuration", e.getMessage());
+            throw e;
+        }
+
+    }
+}

--- a/src/test/java/jenkins/security/plugins/ldap/LDAPConfigurationTest.java
+++ b/src/test/java/jenkins/security/plugins/ldap/LDAPConfigurationTest.java
@@ -29,8 +29,8 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Tests {@link LDAPConfiguration}.
@@ -142,4 +142,39 @@ public class LDAPConfigurationTest {
         assertThat(n1.split("\\s+"), arrayWithSize(s1.split("\\s+").length));
     }
 
+    @Test
+    public void testValidateServerUrlIsSecure_SecureUrl() {
+        String secureUrl = "ldaps://secure.example.com";
+        assertTrue(LDAPConfiguration.validateServerUrlIsSecure(secureUrl));
+    }
+
+    @Test
+    public void testValidateServerUrlIsSecure_InsecureUrl() {
+        String insecureUrl = "ldap://insecure.example.com";
+        assertFalse(LDAPConfiguration.validateServerUrlIsSecure(insecureUrl));
+    }
+
+    @Test
+    public void testValidateServerUrlIsSecure_MixedUrls() {
+        String mixedUrls = "ldaps://secure.example.com ldap://insecure.example.com";
+        assertFalse(LDAPConfiguration.validateServerUrlIsSecure(mixedUrls));
+    }
+
+    @Test
+    public void testValidateServerUrlIsSecure_AllSecureUrls() {
+        String allSecureUrls = "ldaps://secure1.example.com ldaps://secure2.example.com";
+        assertTrue(LDAPConfiguration.validateServerUrlIsSecure(allSecureUrls));
+    }
+
+    @Test
+    public void testValidateServerUrlIsSecure_AllInsecureUrls() {
+        String allInsecureUrls = "ldap://insecure1.example.com ldap://insecure2.example.com";
+        assertFalse(LDAPConfiguration.validateServerUrlIsSecure(allInsecureUrls));
+    }
+
+    @Test
+    public void testValidateServerUrlIsSecure_plainUrl() {
+        String allInsecureUrls = "insecure1.example.com ";
+        assertFalse(LDAPConfiguration.validateServerUrlIsSecure(allInsecureUrls));
+    }
 }

--- a/src/test/resources/jenkins/security/plugins/ldap/casc_ldap_secure.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/casc_ldap_secure.yml
@@ -1,0 +1,18 @@
+jenkins:
+  securityRealm:
+    ldap:
+      configurations:
+        - server: ldaps://ldap.acme.com
+          rootDN: dc=acme,dc=fr
+          managerDN: "manager"
+          managerPasswordSecret: ${LDAP_PASSWORD}
+          userSearch: "(&(objectCategory=User)(sAMAccountName={0}))"
+          groupSearchFilter: "(&(cn={0})(objectclass=group))"
+          groupMembershipStrategy:
+            fromGroupSearch:
+              filter: "(&(objectClass=group)(|(cn=GROUP_1)(cn=GROUP_2)))"
+      cache:
+        size: 100
+        ttl: 10
+      userIdStrategy: CaseInsensitive
+      groupIdStrategy: CaseSensitive


### PR DESCRIPTION
See [JENKINS-73825](https://issues.jenkins.io/browse/JENKINS-73825)
In FIPS mode, now LDAP don't allows the insecure configuration. Also it shows the error messages in case of insecure ldap url/ short password

### Testing
Manually testing is done with below scenarios
1. Configure insecure ldap url & error should thrown + form data should not be saved
2. Configure secure ldap url + form data should not be saved 
3. In advance configuration manager password less than 14 is not allowed
4. CASC configuration unit test to load the ldap configuration i.e. **CasCFipsTest**
     * When configuration has secure url + valid password length => Tested
     * When configuration has insecure url/valid password length **CasCFipsTest.configure_ldap_for_invalid** => Blocked
5. ConfigRoundTrip scenario with FIPS enabled i.e. **LDAPEmbeddedFIPSTest.login()** => Blocked



<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
