### PR TITLE
Test with jsoup API plugin instead of jsoup library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <apacheds.version>2.0.0.AM27</apacheds.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
   <scm>
@@ -258,9 +258,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jsoup</groupId>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.19.1</version>
       <scope>test</scope>
     </dependency>
     
@@ -288,7 +287,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4051.v78dce3ce8b_d6</version>
+        <version>4228.v0a_71308d905b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4488.v7fe26526366e</version>
+        <version>4969.v6ffa_18d90c9f</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4228.v0a_71308d905b_</version>
+        <version>4488.v7fe26526366e</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Test with jsoup API plugin instead of jsoup library

Simplify jsoup API version management by using the version from the plugin bill of materials.

This tests jsoup API 1.21.1 as also proposed in:

* #353 

Supersedes pull requests:

* #363
* #353

Updates the minimum required Jenkins version from 2.479.1 to 2.479.3 per ["Choosing a Jenkins version to build against"](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/)

Pull request should be labeled `tests` but I don't have permission to assign the label.

### Testing done

Confirmed that automated tests pass on Linux with Java 21.  Rely on ci.jenkins.io to test Windows and Java 17.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
