### PR TITLE
Fix Casc test failing after upgrading to CasC 1995.v540b_50a_eb_0c1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.24</version>
+    <version>5.26</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <!-- TODO: remove when included in jenkins-bom via parent -->
       <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <apacheds.version>2.0.0.AM27</apacheds.version>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
   </properties>
 
@@ -266,12 +266,14 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
+      <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>
     
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
+      <version>1995.v540b_50a_eb_0c1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.26</version>
+    <version>5.24</version>
     <relativePath/>
   </parent>
 
@@ -289,7 +289,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>5294.va_d2e144c80e1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/test/resources/jenkins/security/plugins/ldap/LDAPSecurityRealmTestNoSecretExpected.yml
+++ b/src/test/resources/jenkins/security/plugins/ldap/LDAPSecurityRealmTestNoSecretExpected.yml
@@ -2,7 +2,10 @@ cache:
   size: 100
   ttl: 30
 configurations:
-- inhibitInferRootDN: false
+- groupMembershipStrategy:
+    fromGroupSearch: {
+      }
+  inhibitInferRootDN: false
   rootDN: "dc=acme,dc=fr"
   server: "ldap.acme.com"
 disableMailAddressResolver: false


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

After the changes implemented on https://github.com/jenkinsci/configuration-as-code-plugin/pull/2712, there are some failing CasC test on the plugin:

com.cloudbees.jenkins.plugins.platform.CasCTest#smokeExport

The idea behind this PR is to upgrade the CasC plugin dependencies to 1995.v540b_50a_eb_0c1 and fix the failing tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
