### PR TITLE
Update parent, BOM

### DIFF
--- a/.github/workflows/auto-merge-safe-deps.yml
+++ b/.github/workflows/auto-merge-safe-deps.yml
@@ -1,0 +1,9 @@
+name: Automatically approve and merge safe dependency updates
+on:
+- pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge-safe-deps:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/auto-merge-safe-deps.yml@v1

--- a/.github/workflows/close-bom-if-passing.yml
+++ b/.github/workflows/close-bom-if-passing.yml
@@ -1,0 +1,11 @@
+name: Close BOM update PR if passing
+on:
+  check_run:
+    types:
+    - completed
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  close-bom-if-passing:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/close-bom-if-passing.yml@v1

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.10</version>
+    <version>1.13</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2116.v7501b_67dc517</version>
+    <version>6.2152.ve00a_731c3ce9</version>
     <relativePath/>
   </parent>
 
@@ -270,15 +270,12 @@
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <!-- TODO: remove when included in jenkins-bom via parent -->
-      <version>2006.v001a_2ca_6b_574</version>
       <scope>test</scope>
     </dependency>
     
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>2006.v001a_2ca_6b_574</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -288,7 +285,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5888.vd99c2b_38128d</version>
+        <version>5983.v443959746f1f</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Cleanup from #373. Supersedes #369, #613, #619, #636, #637. Sets up https://github.com/jenkins-infra/github-reusable-workflows/pull/48.